### PR TITLE
Documentation fixes.

### DIFF
--- a/doc/internal_protocol.txt
+++ b/doc/internal_protocol.txt
@@ -203,7 +203,7 @@ STATESERVER_OBJECT_QUERY_FIELD_RESP(2062):
 "success" is 1 if the field is present, 0 if the field is nonpresent.
 FIELD is the serialized field, but is only present if success=1.
 
-STATESERVER_OBJECT_SET_AI_CHAANNEL(2045):
+STATESERVER_OBJECT_SET_AI_CHANNEL(2045):
 	(uint32 do_id, uint64 ai_channel)
 Sets the channel for the managing AI. All airecv updates are automatically
 forwarded to this channel.


### PR DESCRIPTION
I had an epiphany that the STATESERVER_QUERY_OBJECT_ALL is NOT for getting all objects on the state server, because it does not have a *_DONE like with zone queries.

It is, instead, a much-needed system for getting an up-to-date object snapshot.

(Oh and I also fixed the CHAANNEL typo.)
