### PR TITLE
Replaced ">>" with "> >" for non-bitshift operations. 

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -7,7 +7,7 @@
 #include "RoleFactory.h"
 LogCategory mainlog("main", "Main");
 
-ConfigVariable<std::vector<std::string>> dc_files("general/dc_files", std::vector<std::string>());
+ConfigVariable<std::vector<std::string> > dc_files("general/dc_files", std::vector<std::string>());
 
 int main(int argc, char *argv[])
 {

--- a/src/database/DatabaseServer.cpp
+++ b/src/database/DatabaseServer.cpp
@@ -230,7 +230,7 @@ class DatabaseServer : public Role
 						return;
 					}
 
-					std::map<DCField*, std::vector<uint8_t>> fields;
+					std::map<DCField*, std::vector<uint8_t> > fields;
 					uint16_t field_count = dgi.read_uint16();
 					m_log->spam() << "Unpacking fields..." << std::endl;
 					try
@@ -370,8 +370,8 @@ class DatabaseServer : public Role
 					}
 
 					// Unpack fields from datagram
-					std::map<DCField*, std::vector<uint8_t>> equals;
-					std::map<DCField*, std::vector<uint8_t>> values;
+					std::map<DCField*, std::vector<uint8_t> > equals;
+					std::map<DCField*, std::vector<uint8_t> > values;
 					uint16_t field_count = dgi.read_uint16();
 					try
 					{
@@ -516,7 +516,7 @@ class DatabaseServer : public Role
 					}
 
 					// Get values from database
-					std::map<DCField*, std::vector<uint8_t>> values;
+					std::map<DCField*, std::vector<uint8_t> > values;
 					if(!m_db_engine->get_fields(do_id, fields, values))
 					{
 						m_log->spam() << "... failure." << std::endl;
@@ -602,7 +602,7 @@ class DatabaseServer : public Role
 
 					uint16_t field_count = dgi.read_uint16();
 					std::vector<DCField*> del_fields;
-					std::map<DCField*, std::vector<uint8_t>> set_fields;
+					std::map<DCField*, std::vector<uint8_t> > set_fields;
 					for(uint16_t i = 0; i < field_count; ++i)
 					{
 						uint16_t field_id = dgi.read_uint16();

--- a/src/database/IDatabaseEngine.h
+++ b/src/database/IDatabaseEngine.h
@@ -8,7 +8,7 @@
 struct DatabaseObject
 {
 	uint16_t dc_id;
-	std::map<DCField*, std::vector<uint8_t>> fields;
+	std::map<DCField*, std::vector<uint8_t> > fields;
 
 	DatabaseObject()
 	{
@@ -32,7 +32,7 @@ class IDatabaseEngine
 		virtual DCClass* get_class(uint32_t do_id) = 0;
 
 #define val_t std::vector<uint8_t>
-#define map_t std::map<DCField*, std::vector<uint8_t>>
+#define map_t std::map<DCField*, std::vector<uint8_t> >
 		virtual void del_field(uint32_t do_id, DCField* field) = 0;
 		virtual void del_fields(uint32_t do_id, const std::vector<DCField*> &fields) = 0;
 

--- a/src/database/YAMLEngine.cpp
+++ b/src/database/YAMLEngine.cpp
@@ -278,7 +278,7 @@ class YAMLEngine : public IDatabaseEngine
 
 
 #define val_t std::vector<uint8_t>
-#define map_t std::map<DCField*, std::vector<uint8_t>>
+#define map_t std::map<DCField*, std::vector<uint8_t> >
 		void del_field(uint32_t do_id, DCField* field)
 		{
 			yamldb_log.spam() << "Deleting field on obj-" << do_id << std::endl;

--- a/src/messagedirector/MessageDirector.cpp
+++ b/src/messagedirector/MessageDirector.cpp
@@ -392,7 +392,7 @@ MessageDirector::MessageDirector() : m_acceptor(NULL), m_initialized(false), is_
 {
 	// Initialize m_range_susbcriptions with empty range
 	auto empty_set = std::set<MDParticipantInterface*>();
-	m_range_subscriptions = boost::icl::interval_map<channel_t, std::set<MDParticipantInterface*>>();
+	m_range_subscriptions = boost::icl::interval_map<channel_t, std::set<MDParticipantInterface*> >();
 	m_range_subscriptions += std::make_pair(interval_t::closed(0, ULLONG_MAX), empty_set);
 }
 

--- a/src/messagedirector/MessageDirector.h
+++ b/src/messagedirector/MessageDirector.h
@@ -76,10 +76,10 @@ class MessageDirector : public NetworkClient
 		std::list<MDParticipantInterface*> m_participants;
 
 		// Single channel subscriptions
-		std::unordered_map<channel_t, std::set<MDParticipantInterface*>> m_channel_subscriptions;
+		std::unordered_map<channel_t, std::set<MDParticipantInterface*> > m_channel_subscriptions;
 
 		// Range channel subscriptions
-		boost::icl::interval_map<channel_t, std::set<MDParticipantInterface*>> m_range_subscriptions;
+		boost::icl::interval_map<channel_t, std::set<MDParticipantInterface*> > m_range_subscriptions;
 
 
 		friend class MDParticipantInterface;

--- a/src/stateserver/DBStateServer.cpp
+++ b/src/stateserver/DBStateServer.cpp
@@ -152,7 +152,7 @@ void DBStateServer::handle_datagram(Datagram &in_dg, DatagramIterator &dgi)
 			uint32_t do_id = dgi.read_uint32();
 			uint16_t field_count = dgi.read_uint16();
 
-			std::unordered_map<DCField*, std::vector<uint8_t>> db_fields;
+			std::unordered_map<DCField*, std::vector<uint8_t> > db_fields;
 			for(uint16_t i=0; i<field_count; ++i)
 			{
 				uint16_t field_id = dgi.read_uint16();
@@ -508,8 +508,8 @@ void DBStateServer::handle_datagram(Datagram &in_dg, DatagramIterator &dgi)
 			DCClass* r_dclass = g_dcf->get_class(dc_id);
 
 			// Get fields from database
-			std::unordered_map<DCField*, std::vector<uint8_t>> required_fields;
-			std::unordered_map<DCField*, std::vector<uint8_t>> ram_fields;
+			std::unordered_map<DCField*, std::vector<uint8_t> > required_fields;
+			std::unordered_map<DCField*, std::vector<uint8_t> > ram_fields;
 			if(!unpack_db_fields(dgi, r_dclass, required_fields, ram_fields))
 			{
 				m_log->error() << "Error while unpacking fields from database." << std::endl;
@@ -576,8 +576,8 @@ void DBStateServer::discard_loader(uint32_t do_id)
 }
 
 bool unpack_db_fields(DatagramIterator &dgi, DCClass* dclass,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &required,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &ram)
+                      std::unordered_map<DCField*, std::vector<uint8_t> > &required,
+                      std::unordered_map<DCField*, std::vector<uint8_t> > &ram)
 {
 	// Unload ram and required fields from database resp
 	uint16_t db_field_count = dgi.read_uint16();

--- a/src/stateserver/DBStateServer.h
+++ b/src/stateserver/DBStateServer.h
@@ -8,8 +8,8 @@
 // from a DBSERVER_GET_ALL_RESP or DBSERVER_GET_FIELDS_RESP message.
 // Returns false if unpacking failed for some reason.
 bool unpack_db_fields(DatagramIterator &dg, DCClass* dclass,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &required,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &ram);
+                      std::unordered_map<DCField*, std::vector<uint8_t> > &required,
+                      std::unordered_map<DCField*, std::vector<uint8_t> > &ram);
 
 class LoadingObject;
 

--- a/src/stateserver/DistributedObject.cpp
+++ b/src/stateserver/DistributedObject.cpp
@@ -57,8 +57,8 @@ DistributedObject::DistributedObject(StateServer *stateserver, uint32_t do_id, u
 
 DistributedObject::DistributedObject(StateServer *stateserver, uint64_t sender, uint32_t do_id,
 	                                 uint32_t parent_id, uint32_t zone_id, DCClass *dclass,
-		                             std::unordered_map<DCField*, std::vector<uint8_t>> required,
-		                             std::unordered_map<DCField*, std::vector<uint8_t>> ram) :
+		                             std::unordered_map<DCField*, std::vector<uint8_t> > required,
+		                             std::unordered_map<DCField*, std::vector<uint8_t> > ram) :
 	m_stateserver(stateserver), m_do_id(do_id), m_parent_id(INVALID_DO_ID), m_zone_id(INVALID_ZONE),
 	m_dclass(dclass), m_ai_channel(INVALID_CHANNEL), m_owner_channel(INVALID_CHANNEL),
 	m_ai_explicitly_set(false), m_next_context(0), m_child_count(0)

--- a/src/stateserver/DistributedObject.h
+++ b/src/stateserver/DistributedObject.h
@@ -11,8 +11,8 @@ class DistributedObject : public MDParticipantInterface
 		                  uint32_t zone_id, DCClass *dclass, DatagramIterator &dgi, bool has_other);
 		DistributedObject(StateServer *stateserver, uint64_t sender, uint32_t do_id,
 		                  uint32_t parent_id, uint32_t zone_id, DCClass *dclass,
-		                  std::unordered_map<DCField*, std::vector<uint8_t>> req_fields,
-		                  std::unordered_map<DCField*, std::vector<uint8_t>> ram_fields);
+		                  std::unordered_map<DCField*, std::vector<uint8_t> > req_fields,
+		                  std::unordered_map<DCField*, std::vector<uint8_t> > ram_fields);
 		~DistributedObject();
 
 		virtual void handle_datagram(Datagram &in_dg, DatagramIterator &dgi);
@@ -48,8 +48,8 @@ class DistributedObject : public MDParticipantInterface
 		uint32_t m_parent_id;
 		uint32_t m_zone_id;
 		DCClass *m_dclass;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_required_fields;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_ram_fields; // TODO: Fix for std::unordered_map
+		std::unordered_map<DCField*, std::vector<uint8_t> > m_required_fields;
+		std::unordered_map<DCField*, std::vector<uint8_t> > m_ram_fields; // TODO: Fix for std::unordered_map
 		channel_t m_ai_channel;
 		channel_t m_owner_channel;
 		bool m_ai_explicitly_set;

--- a/src/stateserver/LoadingObject.h
+++ b/src/stateserver/LoadingObject.h
@@ -27,9 +27,9 @@ class LoadingObject : public MDParticipantInterface
 
 		// Upstream object data
 		DCClass *m_dclass;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_field_updates;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_required_fields;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_ram_fields;
+		std::unordered_map<DCField*, std::vector<uint8_t> > m_field_updates;
+		std::unordered_map<DCField*, std::vector<uint8_t> > m_required_fields;
+		std::unordered_map<DCField*, std::vector<uint8_t> > m_ram_fields;
 
 		// Received datagrams while waiting for reply
 		std::list<Datagram> m_datagram_queue;


### PR DESCRIPTION
This is needed to keep direct compatibility with Mac OS X 10.8/9. Mac OS X 10.8/9 (Xcode 5) Ships with Clang 5 which refuses to compile with the ">>". 
