### PR TITLE
StateServer: Use ordered maps to ensure dcfile-ordering on RAM fields.

### DIFF
--- a/src/stateserver/DBStateServer.cpp
+++ b/src/stateserver/DBStateServer.cpp
@@ -509,7 +509,7 @@ void DBStateServer::handle_datagram(Datagram &in_dg, DatagramIterator &dgi)
 
 			// Get fields from database
 			std::unordered_map<DCField*, std::vector<uint8_t>> required_fields;
-			std::unordered_map<DCField*, std::vector<uint8_t>> ram_fields;
+			std::map<DCField*, std::vector<uint8_t>> ram_fields;
 			if(!unpack_db_fields(dgi, r_dclass, required_fields, ram_fields))
 			{
 				m_log->error() << "Error while unpacking fields from database." << std::endl;
@@ -577,7 +577,7 @@ void DBStateServer::discard_loader(uint32_t do_id)
 
 bool unpack_db_fields(DatagramIterator &dgi, DCClass* dclass,
                       std::unordered_map<DCField*, std::vector<uint8_t>> &required,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &ram)
+                      std::map<DCField*, std::vector<uint8_t>> &ram)
 {
 	// Unload ram and required fields from database resp
 	uint16_t db_field_count = dgi.read_uint16();

--- a/src/stateserver/DBStateServer.h
+++ b/src/stateserver/DBStateServer.h
@@ -9,7 +9,7 @@
 // Returns false if unpacking failed for some reason.
 bool unpack_db_fields(DatagramIterator &dg, DCClass* dclass,
                       std::unordered_map<DCField*, std::vector<uint8_t>> &required,
-                      std::unordered_map<DCField*, std::vector<uint8_t>> &ram);
+                      std::map<DCField*, std::vector<uint8_t>> &ram);
 
 class LoadingObject;
 

--- a/src/stateserver/DistributedObject.cpp
+++ b/src/stateserver/DistributedObject.cpp
@@ -58,7 +58,7 @@ DistributedObject::DistributedObject(StateServer *stateserver, uint32_t do_id, u
 DistributedObject::DistributedObject(StateServer *stateserver, uint64_t sender, uint32_t do_id,
 	                                 uint32_t parent_id, uint32_t zone_id, DCClass *dclass,
 		                             std::unordered_map<DCField*, std::vector<uint8_t>> required,
-		                             std::unordered_map<DCField*, std::vector<uint8_t>> ram) :
+		                             std::map<DCField*, std::vector<uint8_t>> ram) :
 	m_stateserver(stateserver), m_do_id(do_id), m_parent_id(INVALID_DO_ID), m_zone_id(INVALID_ZONE),
 	m_dclass(dclass), m_ai_channel(INVALID_CHANNEL), m_owner_channel(INVALID_CHANNEL),
 	m_ai_explicitly_set(false), m_next_context(0), m_child_count(0)

--- a/src/stateserver/DistributedObject.h
+++ b/src/stateserver/DistributedObject.h
@@ -12,7 +12,7 @@ class DistributedObject : public MDParticipantInterface
 		DistributedObject(StateServer *stateserver, uint64_t sender, uint32_t do_id,
 		                  uint32_t parent_id, uint32_t zone_id, DCClass *dclass,
 		                  std::unordered_map<DCField*, std::vector<uint8_t>> req_fields,
-		                  std::unordered_map<DCField*, std::vector<uint8_t>> ram_fields);
+		                  std::map<DCField*, std::vector<uint8_t>> ram_fields);
 		~DistributedObject();
 
 		virtual void handle_datagram(Datagram &in_dg, DatagramIterator &dgi);
@@ -49,7 +49,7 @@ class DistributedObject : public MDParticipantInterface
 		uint32_t m_zone_id;
 		DCClass *m_dclass;
 		std::unordered_map<DCField*, std::vector<uint8_t>> m_required_fields;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_ram_fields; // TODO: Fix for std::unordered_map
+		std::map<DCField*, std::vector<uint8_t>> m_ram_fields;
 		channel_t m_ai_channel;
 		channel_t m_owner_channel;
 		bool m_ai_explicitly_set;

--- a/src/stateserver/LoadingObject.h
+++ b/src/stateserver/LoadingObject.h
@@ -29,7 +29,7 @@ class LoadingObject : public MDParticipantInterface
 		DCClass *m_dclass;
 		std::unordered_map<DCField*, std::vector<uint8_t>> m_field_updates;
 		std::unordered_map<DCField*, std::vector<uint8_t>> m_required_fields;
-		std::unordered_map<DCField*, std::vector<uint8_t>> m_ram_fields;
+		std::map<DCField*, std::vector<uint8_t>> m_ram_fields;
 
 		// Received datagrams while waiting for reply
 		std::list<Datagram> m_datagram_queue;


### PR DESCRIPTION
(Tests pending on this. This pull request is intended for discussion and only includes code for ease of applying the change if we agree.)

Some applications may have very fickle objects that expect to receive state information in a specific order. In cases like this, the developer might want to use a certain ordering in their DC file to make sure the updates are applied in order. For example:

```
dclass DistributedHat {
    uint8 hatType required broadcast;
    uint8 hatColorIndex required broadcast;
};
```

In this case, required fields are sorted by their index, so the application is guaranteed to receive them from the SS in the dc file order.

However, in a case like:

```
dclass DistributedPlayer {
    uint8 hasHat required broadcast;
    uint8 hatType ram broadcast;
    uint8 hatColorIndex ram broadcast;
};
```

...the State Server may conceivably reorder the RAM fields and put the color information before the type, causing the application to color a not-yet-loaded hat.

I feel like adding a specific ordering behavior to the Astron design is appropriate. I'm up for some discussion about whether it's better to do this sort of thing in the libraries or in the State Server itself, but I think the SS is the best place for such a change because it provides a guarantee that everything will follow this behavior.
