### PR TITLE
Small changes to datagram to allow for subclass-ability. Added Fields

### DIFF
--- a/src/util/Datagram.h
+++ b/src/util/Datagram.h
@@ -7,7 +7,7 @@
 
 class Datagram
 {
-	private:
+	protected:
 		uint8_t* buf;
 		uint32_t buf_size;
 		uint32_t buf_end;
@@ -96,6 +96,20 @@ class Datagram
 			buf_end += 8;
 		}
 
+		void add_float64(const double &v)
+		{
+			check_add_length(8);
+			memcpy(buf + buf_end, &v, 8);
+			buf_end += 8;
+		}
+
+		void add_float32(const float &v)
+		{
+			check_add_length(4);
+			memcpy(buf + buf_end, &v, 4);
+			buf_end += 4;
+		}
+
 		void add_data(const std::vector<uint8_t> &data)
 		{
 			if(data.size())
@@ -127,6 +141,7 @@ class Datagram
 			memcpy(buf + buf_end, str.c_str(), str.length());
 			buf_end += str.length();
 		}
+
 
 		void add_server_header(channel_t to, channel_t from, uint16_t message_type)
 		{

--- a/src/util/DatagramIterator.h
+++ b/src/util/DatagramIterator.h
@@ -17,7 +17,7 @@ class DatagramIteratorEOF : public std::runtime_error
 
 class DatagramIterator
 {
-	private:
+	protected:
 		const Datagram &m_dg;
 		uint16_t m_offset;
 
@@ -69,12 +69,38 @@ class DatagramIterator
 			return r;
 		}
 
+		double read_float64()
+		{
+			check_read_length(8);
+			double r = *(double*)(m_dg.get_data() + m_offset);
+			m_offset += 8;
+			return r;
+		}
+
+		float read_float32()
+		{
+			check_read_length(4);
+			float r = *(float*)(m_dg.get_data() + m_offset);
+			m_offset += 4;
+			return r;
+		}
+
+
+
 		// read_string reads a string from the datagram in format [len][<string-std::vector<uint8_t>>].
 		// OTP messages are prefixed with a length, so this can be used to read the entire
 		//     datagram, primarily useful to archive a datagram for later processing.
 		std::string read_string()
 		{
 			uint32_t length = read_uint16();
+			check_read_length(length);
+			std::string str((char*)(m_dg.get_data() + m_offset), length);
+			m_offset += length;
+			return str;
+		}
+
+		std::string read_string(uint32_t length)
+		{
 			check_read_length(length);
 			std::string str((char*)(m_dg.get_data() + m_offset), length);
 			m_offset += length;


### PR DESCRIPTION
Datagrams should be subclass able. For instance, with my project all packets to and from the game are big-endian. To account for this, a custom subclass of datagram and datagramIterator is the logical approach.

Also added Add and read float64 and float32 for floating point numbers in datagrams. 
