### PR TITLE
Changed connection string from “sqlite” to “sqlite3” to please SociSQL

### DIFF
--- a/src/database/SociSQLDatabase.cpp
+++ b/src/database/SociSQLDatabase.cpp
@@ -496,7 +496,7 @@ class SociSQLDatabase : public DatabaseBackend
 				           << "user=" << m_sess_user << " "
 				           << "pass='" << m_sess_passwd << "'";
 			}
-			else if(m_backend == "sqlite")
+			else if(m_backend == "sqlite3")
 			{
 				connstring << m_db_name;
 			}
@@ -760,4 +760,4 @@ class SociSQLDatabase : public DatabaseBackend
 
 DBBackendFactoryItem<SociSQLDatabase> mysql_factory("mysql");
 DBBackendFactoryItem<SociSQLDatabase> postgresql_factory("postgresql");
-DBBackendFactoryItem<SociSQLDatabase> sqlite_factory("sqlite");
+DBBackendFactoryItem<SociSQLDatabase> sqlite_factory("sqlite3");


### PR DESCRIPTION
SociSQLDatabase.cpp:499 looks for the string "sqlite" not "sqlite3",  which results in a "libc++abi.dylib: terminating with uncaught exception of type soci::soci_error: Failed to find shared library for backend sqlite".

Correct backend name should be sqlite3. see http://soci.sourceforge.net/doc/3.2/backends/sqlite3.html
