### PR TITLE
ClientAgent: add missing break

### DIFF
--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -431,6 +431,7 @@ void Client::handle_datagram(DatagramHandle, DatagramIterator &dgi)
 
 			m_declared_objects.erase(do_id);
 		}
+		break;
 		case CLIENTAGENT_SET_FIELDS_SENDABLE:
 		{
 			doid_t do_id = dgi.read_doid();


### PR DESCRIPTION
A small fix for a problem that was generating 'truncated datagram' errors for me.
