### PR TITLE
Basic color output

### DIFF
--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -145,8 +145,12 @@ class Logger
 
 		// get_min_severity returns the current minimum severity that will be logged by the logger.
 		LogSeverity get_min_severity();
+	
+		bool m_colorEnable;
 
 	private:
+		const char* get_severity_color(LogSeverity sev);
+	
 		LoggerBuf m_buf;
 		LogSeverity m_severity;
 		std::ostream m_output;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -34,6 +34,8 @@ int main(int argc, char *argv[])
 {
 	string cfg_file;
 
+	bool prettyPrint = true;
+	
 	int config_arg_index = -1;
 	cfg_file = "astrond.yml";
 	LogSeverity sev = g_logger->get_min_severity();
@@ -84,6 +86,15 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 		}
+		else if(strcmp(argv[i], "--pretty") == 0 || strcmp(argv[i], "-p") == 0)
+		{
+			if( strcmp(argv[++i], "off") == 0)
+			{
+				prettyPrint = false;
+			} else {
+				prettyPrint = true;
+			}
+		}
 		else if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
 		{
 			printHelp(cout);
@@ -110,6 +121,8 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
+	
+	g_logger->m_colorEnable = prettyPrint;
 
 	if(config_arg_index != -1)
 	{
@@ -248,6 +261,7 @@ void printHelp(ostream &s)
 	     "\n"
 	     "-h, --help      Print this help dialog.\n"
 	     "-L, --log       Specify a file to write log messages to.\n"
+		 "-p, --pretty    Enable/disable colored pretty printing (use on or off). \n"
 	     "-l, --loglevel  Specify the minimum log level that should be logged;\n"
 	     "                  Security, Error, and Fatal will always be logged;\n"
 #ifdef ASTRON_DEBUG_MESSAGES


### PR DESCRIPTION
Note: Windows users will either have to run it with --pretty off, use a program like ansicon, or be subjected to evil code on the terminal screen.
