### PR TITLE
Bugfix for compilation on windows, fixes #245

### DIFF
--- a/src/util/password_prompt.cpp
+++ b/src/util/password_prompt.cpp
@@ -18,7 +18,7 @@ char *getpass(const char *prompt)
 
     string password;
     getline(cin, password);
-    return password;
+    return password.c_str();
 }
 
 


### PR DESCRIPTION
*\* THIS HAS NOT BEEN TESTED **

This should fix the issue as it will return a char \* instead of a string, but I cannot test it on a Windows machine for several hours. Sorry to put the testing on you guys. :(
