### PR TITLE
Missing Include

### DIFF
--- a/src/util/password_prompt.cpp
+++ b/src/util/password_prompt.cpp
@@ -24,6 +24,7 @@ string password_prompt(const string& prompt)
 
 #else
 // Defined in unistd.h
+#include <stdlib.h>
 #include <unistd.h>
 string password_prompt(const string& prompt)
 {


### PR DESCRIPTION
Fixes a compiler error I was getting on the latest master.
