### PR TITLE
bugfix: Whenever deleting m_log, verify that it is not null. Change to null after delete.

### DIFF
--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -27,7 +27,10 @@ Client::Client(ClientAgent* client_agent) : m_client_agent(client_agent)
 
 Client::~Client()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 void Client::annihilate()

--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -191,7 +191,10 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
 
 ClientAgent::~ClientAgent()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 // handle_tcp generates a new Client object from a raw tcp connection.

--- a/src/stateserver/DBStateServer.cpp
+++ b/src/stateserver/DBStateServer.cpp
@@ -44,7 +44,10 @@ DBStateServer::DBStateServer(RoleConfig roleconfig) : StateServer(roleconfig),
 
 DBStateServer::~DBStateServer()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 void DBStateServer::handle_datagram(DatagramHandle, DatagramIterator &dgi)

--- a/src/stateserver/DistributedObject.cpp
+++ b/src/stateserver/DistributedObject.cpp
@@ -73,7 +73,10 @@ DistributedObject::DistributedObject(StateServer *stateserver, channel_t sender,
 
 DistributedObject::~DistributedObject()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 void DistributedObject::append_required_data(DatagramPtr dg, bool client_only, bool also_owner)

--- a/src/stateserver/LoadingObject.cpp
+++ b/src/stateserver/LoadingObject.cpp
@@ -34,7 +34,10 @@ LoadingObject::LoadingObject(DBStateServer *stateserver, doid_t do_id, doid_t pa
 
 LoadingObject::~LoadingObject()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 void LoadingObject::begin()

--- a/src/stateserver/StateServer.cpp
+++ b/src/stateserver/StateServer.cpp
@@ -30,7 +30,10 @@ StateServer::StateServer(RoleConfig roleconfig) : Role(roleconfig)
 
 StateServer::~StateServer()
 {
-    delete m_log;
+    if(m_log) {
+        delete m_log;
+        m_log = nullptr;
+    }
 }
 
 void StateServer::handle_generate(DatagramIterator &dgi, bool has_other)


### PR DESCRIPTION
This fixes a double-free in cases of inheritance.
