### PR TITLE
Bugfix: MolecularField should not pass the class to the Field base when constructing.

### DIFF
--- a/src/dclass/dc/Field.cpp
+++ b/src/dclass/dc/Field.cpp
@@ -13,11 +13,14 @@ Field::Field(DistributedType* type, const std::string &name) :
     m_struct(NULL), m_id(0), m_name(name), m_type(type), m_has_default_value(false)
 {
     bool implicit_value;
-    m_default_value = create_default_value(type, implicit_value);
-    m_has_default_value = !implicit_value;
 
     if(m_type == NULL) {
         m_type = DistributedType::invalid;
+    }
+    else
+    {
+        m_default_value = create_default_value(type, implicit_value);
+        m_has_default_value = !implicit_value;
     }
 }
 

--- a/src/dclass/dc/MolecularField.cpp
+++ b/src/dclass/dc/MolecularField.cpp
@@ -9,7 +9,7 @@ namespace dclass   // open namespace dclass
 
 // constructor
 MolecularField::MolecularField(Class* cls, const std::string &name) :
-    Field(cls, name), Struct(cls->get_file())
+    Field(NULL, name), Struct(cls->get_file())
 {
     Field::m_type = this;
 }


### PR DESCRIPTION
This will cause the Field base to enumerate the default values of all fields in the class.
Instead, pass NULL. m_type is changed anyway, so this isn't an issue.

In addition to everything else, this also makes Astron use a **ton** less memory (87% reduction in my very informal testing) for DC files with lots of moleculars, since each molecular's default is calculated and allocated correctly.