### PR TITLE
Resolve database race condition with multithreaded backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,8 @@ if(BUILD_DBSERVER)
 		src/database/DatabaseBackend.cpp
 		src/database/DBOperation.h
 		src/database/DBOperation.cpp
+		src/database/DBOperationQueue.h
+		src/database/DBOperationQueue.cpp
 		src/database/OldDatabaseBackend.h
 		src/database/OldDatabaseBackend.cpp
 		src/database/DBBackendFactory.h

--- a/src/database/DBOperation.cpp
+++ b/src/database/DBOperation.cpp
@@ -10,6 +10,8 @@ using dclass::Class;
 
 void DBOperation::cleanup()
 {
+    m_dbserver->clear_operation(this);
+
     delete this;
 }
 

--- a/src/database/DBOperation.cpp
+++ b/src/database/DBOperation.cpp
@@ -295,6 +295,42 @@ bool DBOperationGet::verify_class(const dclass::Class *dclass)
     return true;
 }
 
+bool DBOperationGet::is_independent_of(const DBOperation *other) const
+{
+    if(doid() != other->doid()) {
+        // Not even operating on the same doId; we're good.
+        return true;
+    }
+
+    switch(other->type()) {
+        case GET_OBJECT:
+        case GET_FIELDS:
+            return true;
+
+        case SET_FIELDS:
+        case UPDATE_FIELDS:
+            if(type() == GET_OBJECT) {
+                // A GET_OBJECT gets everything, and is therefore not
+                // independent of any changes to the object.
+                return false;
+            }
+
+            // Test if any of the fields we're getting is a field changed by
+            // the other operation...
+            for(auto it = get_fields().begin(); it != get_fields().end(); ++it) {
+                if(other->set_fields().find(*it) != other->set_fields().end()) {
+                    return false;
+                }
+            }
+
+            // No conflict.
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 void DBOperationGet::on_failure()
 {
     DatagramPtr resp = Datagram::create();
@@ -402,6 +438,51 @@ bool DBOperationSet::verify_class(const dclass::Class *dclass)
     return true;
 }
 
+bool DBOperationSet::is_independent_of(const DBOperation *other) const
+{
+    if(doid() != other->doid()) {
+        // Not even operating on the same doId; we're good.
+        return true;
+    }
+
+    switch(other->type()) {
+        case GET_OBJECT:
+        case GET_FIELDS:
+            // The logic for this is in DBOperationGet... Let's let that take
+            // care of it.
+            return other->is_independent_of(this);
+
+        case SET_FIELDS:
+            // The operations are independent as long as they're on different
+            // fields.
+
+            for(auto it = set_fields().begin(); it != set_fields().end(); ++it) {
+                if(other->set_fields().find(it->first) != other->set_fields().end()) {
+                    return false;
+                }
+            }
+
+            // No conflict.
+            return true;
+
+        case UPDATE_FIELDS:
+            // We must be independent of the other operation's fields *AND*
+            // their criteria.
+            for(auto it = set_fields().begin(); it != set_fields().end(); ++it) {
+                if(other->set_fields().find(it->first) != other->set_fields().end() ||
+                   other->criteria_fields().find(it->first) != other->criteria_fields().end()) {
+                    return false;
+                }
+            }
+
+            // No conflict.
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 void DBOperationSet::on_complete()
 {
     // Broadcast update to object's channel
@@ -469,6 +550,50 @@ bool DBOperationUpdate::verify_class(const dclass::Class *dclass)
         errors = true;
     }
     return !errors;
+}
+
+bool DBOperationUpdate::is_independent_of(const DBOperation *other) const
+{
+    if(doid() != other->doid()) {
+        // Not even operating on the same doId; we're good.
+        return true;
+    }
+
+    switch(other->type()) {
+        case GET_OBJECT:
+        case GET_FIELDS:
+        case SET_FIELDS:
+            // The logic for handling these types is elsewhere.
+            return other->is_independent_of(this);
+
+        case UPDATE_FIELDS:
+            // This case gets really tricky. Not only may our set fields not
+            // conflict with their set fields/criteria, but our *criteria* may
+            // not overlap with their set fields. It *is* okay, however, to
+            // have a criteria overlap.
+            for(auto it = set_fields().begin(); it != set_fields().end(); ++it) {
+                if(other->set_fields().find(it->first) != other->set_fields().end() ||
+                   other->criteria_fields().find(it->first) != other->criteria_fields().end()) {
+                    return false;
+                }
+            }
+
+            // Our set fields don't conflict, let's see if their set fields
+            // conflict.
+            for(auto it = other->set_fields().begin(); it != other->set_fields().end(); ++it) {
+                // We're only testing against our criteria_fields()... The
+                // set_fields()<->set_fields() intersection was already tested.
+                if(criteria_fields().find(it->first) != criteria_fields().end()) {
+                    return false;
+                }
+            }
+
+            // No conflict.
+            return true;
+
+        default:
+            return false;
+    }
 }
 
 void DBOperationUpdate::on_complete()

--- a/src/database/DBOperation.h
+++ b/src/database/DBOperation.h
@@ -125,6 +125,28 @@ class DBOperation
         return true;
     }
 
+    // This function determines whether two DBOperations are "independent" --
+    // in other words, the outcome of one operation does not affect the other,
+    // which makes their ordering unimportant. This is useful for concurrency -
+    // if two operations are independent, it's safe to execute them in
+    // parallel.
+    //
+    // This function MUST ONLY return true if the lack of ordering is safe,
+    // but may return false in cases of uncertainty (i.e. two operations that
+    // are actually independent may report that they are *not* independent
+    // because it still would not be safe to execute them out of order).
+    //
+    // Note that this relation must also be symmetric. In other words,
+    // a->is_independent_of(b) == b->is_independent_of(a)
+    virtual bool is_independent_of(const DBOperation *other) const
+    {
+        // By default, we only assume operations are independent if they
+        // operate on different doIds. CREATEs are assumed never independent -
+        // their ordering is very much important - but their doid() is invalid
+        // and invalid != invalid is false.
+        return doid() != other->doid();
+    }
+
     // === CALLBACK FUNCTION ===
     // The database backend invokes these when the operation completes.
     // N.B. when this happens, the DBOperation regains control of its own
@@ -158,7 +180,7 @@ class DBOperation
 
 
   protected:
-    // The DBServer the operation is acting om.
+    // The DBServer the operation is acting on.
     DatabaseServer *m_dbserver;
     // The sender of the operation.
     channel_t m_sender;

--- a/src/database/DBOperation.h
+++ b/src/database/DBOperation.h
@@ -232,6 +232,7 @@ class DBOperationGet : public DBOperation
     DBOperationGet(DatabaseServer *db) : DBOperation(db) { }
     virtual bool initialize(channel_t sender, uint16_t msg_type, DatagramIterator &dgi);
     virtual bool verify_class(const dclass::Class *dclass);
+    virtual bool is_independent_of(const DBOperation *other) const;
     virtual void on_complete(DBObjectSnapshot *snapshot);
     virtual void on_failure();
 
@@ -245,6 +246,7 @@ class DBOperationSet : public DBOperation
     DBOperationSet(DatabaseServer *db) : DBOperation(db) { }
     virtual bool initialize(channel_t sender, uint16_t msg_type, DatagramIterator &dgi);
     virtual bool verify_class(const dclass::Class *dclass);
+    virtual bool is_independent_of(const DBOperation *other) const;
     virtual void on_complete();
     virtual void on_failure();
 };
@@ -254,6 +256,7 @@ class DBOperationUpdate : public DBOperation
     DBOperationUpdate(DatabaseServer *db) : DBOperation(db) { }
     virtual bool initialize(channel_t sender, uint16_t msg_type, DatagramIterator &dgi);
     virtual bool verify_class(const dclass::Class *dclass);
+    virtual bool is_independent_of(const DBOperation *other) const;
     virtual void on_complete();
     virtual void on_failure();
     virtual void on_criteria_mismatch(DBObjectSnapshot *);

--- a/src/database/DBOperationQueue.cpp
+++ b/src/database/DBOperationQueue.cpp
@@ -20,17 +20,22 @@ DBOperation *DBOperationQueue::get_next_operation()
     }
 }
 
-bool DBOperationQueue::begin_operation(DBOperation *op)
+bool DBOperationQueue::enqueue_operation(DBOperation *op)
 {
-    if(can_operation_start(op)) {
-        m_running_operations.insert(op);
-
-        return true;
+    if(!m_queue.size() && can_operation_start(op)) {
+        // The queue is empty and this operation can go straight away! Let's
+        // refuse to enqueue it.
+        return false;
     } else {
         m_queue.push(op);
 
-        return false;
+        return true;
     }
+}
+
+void DBOperationQueue::begin_operation(DBOperation *op)
+{
+    m_running_operations.insert(op);
 }
 
 bool DBOperationQueue::finalize_operation(const DBOperation *op)

--- a/src/database/DBOperationQueue.cpp
+++ b/src/database/DBOperationQueue.cpp
@@ -1,0 +1,50 @@
+#include "DBOperationQueue.h"
+
+DBOperation *DBOperationQueue::get_next_operation()
+{
+    if(!m_queue.size()) {
+        return nullptr;
+    }
+
+    DBOperation *op = m_queue.front();
+
+    if(can_operation_start(op)) {
+        m_running_operations.insert(op);
+        m_queue.pop();
+        return op;
+    } else {
+        return nullptr;
+    }
+}
+
+bool DBOperationQueue::begin_operation(DBOperation *op)
+{
+    if(can_operation_start(op)) {
+        m_running_operations.insert(op);
+
+        return true;
+    } else {
+        m_queue.push(op);
+
+        return false;
+    }
+}
+
+bool DBOperationQueue::finalize_operation(const DBOperation *op)
+{
+    m_running_operations.erase(op);
+
+    // TODO: This should check to see if it conflicts with the next queued
+    // operation. If this didn't conflict, then the next operation in the queue
+    // is obviously blocked by something else, and we shouldn't bother to run
+    // it through can_operation_start.
+    return true;
+}
+
+bool DBOperationQueue::can_operation_start(const DBOperation *op)
+{
+    // TODO: Currently, this just waits until the running operations map is
+    // empty. The desired behavior is to check if "op" conflicts with any of the
+    // database operations in m_running_operations.
+    return !m_running_operations.size();
+}

--- a/src/database/DBOperationQueue.cpp
+++ b/src/database/DBOperationQueue.cpp
@@ -13,7 +13,6 @@ DBOperation *DBOperationQueue::get_next_operation()
     DBOperation *op = m_queue.front();
 
     if(can_operation_start(op)) {
-        m_running_operations.insert(op);
         m_queue.pop();
         return op;
     } else {

--- a/src/database/DBOperationQueue.cpp
+++ b/src/database/DBOperationQueue.cpp
@@ -41,6 +41,11 @@ bool DBOperationQueue::finalize_operation(const DBOperation *op)
     return true;
 }
 
+bool DBOperationQueue::is_empty() const
+{
+    return !m_queue.size() && !m_running_operations.size();
+}
+
 bool DBOperationQueue::can_operation_start(const DBOperation *op)
 {
     // TODO: Currently, this just waits until the running operations map is

--- a/src/database/DBOperationQueue.h
+++ b/src/database/DBOperationQueue.h
@@ -17,10 +17,12 @@ class DBOperationQueue
     DBOperation *get_next_operation();
 
     // Inform the queue that we'd like to begin an operation. If the operation
-    // can start right away, this returns true, and it is recorded as a
-    // "running operation". If this cannot start, it will be enqueued and this
-    // function will return false.
-    bool begin_operation(DBOperation *op);
+    // can start right away, this returns false, If this cannot start, it will
+    // be enqueued and this function will return true.
+    bool enqueue_operation(DBOperation *op);
+
+    // Inform the queue that an operation is now running.
+    void begin_operation(DBOperation *op);
 
     // Inform the queue that an operation has completed. If this might allow the
     // next queued operation to begin, this will return true.

--- a/src/database/DBOperationQueue.h
+++ b/src/database/DBOperationQueue.h
@@ -26,6 +26,9 @@ class DBOperationQueue
     // next queued operation to begin, this will return true.
     bool finalize_operation(const DBOperation *op);
 
+    // Is this queue empty (i.e. can it safely be deleted from the map)?
+    bool is_empty() const;
+
   private:
     std::queue<DBOperation *> m_queue;
     std::unordered_set<const DBOperation *> m_running_operations;

--- a/src/database/DBOperationQueue.h
+++ b/src/database/DBOperationQueue.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <queue>
+#include <unordered_set>
+
+#include "DBOperation.h"
+
+// Represents the database operations queued up for a single object, blocking any
+// operations that may conflict with operations currently being run. This is
+// to ensure that any given sequence of operations will complete as if they had
+// run one at a time.
+class DBOperationQueue
+{
+  public:
+    // Return the next operation that we can run on this object, or nullptr if
+    // there are no safe operations in the queue.
+    // This will automatically mark the returned operation as "running"
+    DBOperation *get_next_operation();
+
+    // Inform the queue that we'd like to begin an operation. If the operation
+    // can start right away, this returns true, and it is recorded as a
+    // "running operation". If this cannot start, it will be enqueued and this
+    // function will return false.
+    bool begin_operation(DBOperation *op);
+
+    // Inform the queue that an operation has completed. If this might allow the
+    // next queued operation to begin, this will return true.
+    bool finalize_operation(const DBOperation *op);
+
+  private:
+    std::queue<DBOperation *> m_queue;
+    std::unordered_set<const DBOperation *> m_running_operations;
+
+    // Inspects an operation to see if it can begin immediately.
+    bool can_operation_start(const DBOperation *op);
+};

--- a/src/database/DatabaseServer.cpp
+++ b/src/database/DatabaseServer.cpp
@@ -109,6 +109,8 @@ void DatabaseServer::handle_operation(DBOperation *op)
         return;
     }
 
+    unique_lock<recursive_mutex> guard(m_lock);
+
     DBOperationQueue &queue = m_queues[op->doid()];
 
     if(queue.begin_operation(op)) {
@@ -122,6 +124,8 @@ void DatabaseServer::clear_operation(const DBOperation *op)
         // CREATEs do not operate on a specific doId and are therefore non-queued.
         return;
     }
+
+    unique_lock<recursive_mutex> guard(m_lock);
 
     DBOperationQueue &queue = m_queues[op->doid()];
 

--- a/src/database/DatabaseServer.cpp
+++ b/src/database/DatabaseServer.cpp
@@ -133,6 +133,7 @@ void DatabaseServer::clear_operation(const DBOperation *op)
         // The queue says there's a chance this would allow later operations to
         // begin; let's submit all of the eligible operations.
         while(DBOperation *next_op = queue.get_next_operation()) {
+            queue.begin_operation(next_op);
             m_db_backend->submit(next_op);
         }
     }

--- a/src/database/DatabaseServer.cpp
+++ b/src/database/DatabaseServer.cpp
@@ -113,7 +113,8 @@ void DatabaseServer::handle_operation(DBOperation *op)
 
     DBOperationQueue &queue = m_queues[op->doid()];
 
-    if(queue.begin_operation(op)) {
+    if(!queue.enqueue_operation(op)) {
+        queue.begin_operation(op);
         m_db_backend->submit(op);
     }
 }

--- a/src/database/DatabaseServer.h
+++ b/src/database/DatabaseServer.h
@@ -20,6 +20,7 @@ class DatabaseServer : public Role
     void handle_operation(DBOperation *op);
     void clear_operation(const DBOperation *op);
     std::unordered_map<doid_t, DBOperationQueue> m_queues;
+    std::recursive_mutex m_lock;
 
     DatabaseBackend *m_db_backend;
     LogCategory *m_log;

--- a/src/database/DatabaseServer.h
+++ b/src/database/DatabaseServer.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <unordered_map>
+
 #include "core/Role.h"
 #include "core/RoleFactory.h"
 #include "DatabaseBackend.h"
 #include "DBOperation.h"
+#include "DBOperationQueue.h"
 
 extern RoleConfigGroup dbserver_config;
 
@@ -15,6 +18,8 @@ class DatabaseServer : public Role
 
   private:
     void handle_operation(DBOperation *op);
+    void clear_operation(const DBOperation *op);
+    std::unordered_map<doid_t, DBOperationQueue> m_queues;
 
     DatabaseBackend *m_db_backend;
     LogCategory *m_log;
@@ -29,4 +34,6 @@ class DatabaseServer : public Role
     friend class DBOperationGet;
     friend class DBOperationSet;
     friend class DBOperationUpdate;
+
+    friend class DBOperationQueue;
 };


### PR DESCRIPTION
This implements a more disciplined work queue into the database server that ensures that no two conflicting operations will be submitted to the backend at once. The current implementation will only allow one operation on a doId to run at a time (with the exception of GET_FIELDS/GET_OBJECT, which can run as much as it wants). In the future I'd like to figure out how to get the DBOperation::is_independent_of function working better so that it can properly detect when it can safely coexist with another operation.