### PR TITLE
Fix linking error on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")		### Linux requires pthreads
 	set(CMAKE_CXX_FLAGS "-pthread -lrt")
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")		### FreeBSD does not use -lrt
+	set(CMAKE_CXX_FLAGS "-pthread")
+endif()
+
 ### YAML Depedency -- required by config, used by yaml database ###
 set(YAMLCPP_USE_STATIC_LIBS ON CACHE BOOL "If true, will try to find static YamlCpp first instead of dynamic.")
 find_package(YamlCpp)


### PR DESCRIPTION
I fixed the error when linking Astron on FreeBSD. FreeBSD does need -pthread but not -lrt.
