### PR TITLE
Refactor NetworkClient

### DIFF
--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -656,9 +656,14 @@ class AstronClient : public Client, public NetworkClient
         return get_remote().port();
     }
 
-    virtual const tcp::socket* get_socket()
+    virtual const std::string get_local_address()
     {
-        return m_socket;
+        return get_local().address().to_string();
+    }
+
+    virtual uint16_t get_local_port()
+    {
+        return get_local().port();
     }
 };
 

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -109,8 +109,8 @@ class AstronClient : public Client, public NetworkClient
         }
 
         stringstream ss;
-        ss << "Client (" << m_remote.address().to_string()
-           << ":" << m_remote.port() << ", " << m_channel << ")";
+        ss << "Client (" << get_remote().address().to_string()
+           << ":" << get_remote().port() << ", " << m_channel << ")";
         m_log->set_name(ss.str());
         set_con_name(ss.str());
 
@@ -119,8 +119,8 @@ class AstronClient : public Client, public NetworkClient
 
         // Add remote endpoint to log
         ss.str(""); // empty the stream
-        ss << m_remote.address().to_string()
-           << ":" << m_remote.port();
+        ss << get_remote().address().to_string()
+           << ":" << get_remote().port();
         event.add("remote_address", ss.str());
 
         // Add local endpoint to log
@@ -648,12 +648,12 @@ class AstronClient : public Client, public NetworkClient
 
     virtual const std::string get_remote_address()
     {
-        return m_remote.address().to_string();
+        return get_remote().address().to_string();
     }
 
     virtual uint16_t get_remote_port()
     {
-        return m_remote.port();
+        return get_remote().port();
     }
 
     virtual const tcp::socket* get_socket()

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -125,8 +125,8 @@ class AstronClient : public Client, public NetworkClient
 
         // Add local endpoint to log
         ss.str(""); // empty the stream
-        ss << m_socket->local_endpoint().address().to_string()
-           << ":" << m_socket->local_endpoint().port();
+        ss << get_local().address().to_string()
+           << ":" << get_local().port();
         event.add("local_address", ss.str());
 
         // Log created event

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -57,24 +57,28 @@ class AstronClient : public Client, public NetworkHandler
 
   public:
     AstronClient(ConfigNode config, ClientAgent* client_agent, tcp::socket *socket) :
-        Client(config, client_agent), m_client(this, socket), m_config(config),
+        Client(config, client_agent), m_client(this), m_config(config),
         m_clean_disconnect(false), m_relocate_owned(relocate_owned.get_rval(config)),
         m_send_hash(send_hash_to_client.get_rval(config)),
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
         initialize();
+
+        m_client.set_socket(socket);
     }
 
     AstronClient(ConfigNode config, ClientAgent* client_agent,
                  ssl::stream<tcp::socket> *stream) :
-        Client(config, client_agent), m_client(this, stream), m_config(config),
+        Client(config, client_agent), m_client(this), m_config(config),
         m_clean_disconnect(false), m_relocate_owned(relocate_owned.get_rval(config)),
         m_send_hash(send_hash_to_client.get_rval(config)),
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
         initialize();
+
+        m_client.set_socket(stream);
     }
 
     ~AstronClient()

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -149,7 +149,7 @@ class AstronClient : public Client, public NetworkHandler
             m_client.send_datagram(resp);
 
             m_clean_disconnect = true;
-            m_client.send_disconnect();
+            m_client.disconnect();
         }
     }
 
@@ -226,7 +226,7 @@ class AstronClient : public Client, public NetworkHandler
     virtual void handle_drop()
     {
         m_clean_disconnect = true;
-        m_client.send_disconnect();
+        m_client.disconnect();
     }
 
     // handle_add_interest should inform the client of an interest added by the server.
@@ -409,7 +409,7 @@ class AstronClient : public Client, public NetworkHandler
             log_event(event);
 
             m_clean_disconnect = true;
-            m_client.send_disconnect();
+            m_client.disconnect();
         }
         break;
         case CLIENT_OBJECT_SET_FIELD:
@@ -437,7 +437,7 @@ class AstronClient : public Client, public NetworkHandler
             log_event(event);
 
             m_clean_disconnect = true;
-            m_client.send_disconnect();
+            m_client.disconnect();
         }
         break;
         case CLIENT_OBJECT_SET_FIELD:

--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -446,8 +446,8 @@ void Client::handle_datagram(DatagramHandle in_dg, DatagramIterator &dgi)
         resp->add_uint32(dgi.read_uint32()); // Context
         resp->add_string(get_remote_address());
         resp->add_uint16(get_remote_port());
-        resp->add_string(get_socket()->local_endpoint().address().to_string());
-        resp->add_uint16(get_socket()->local_endpoint().port());
+        resp->add_string(get_local_address());
+        resp->add_uint16(get_local_port());
         route_datagram(resp);
     }
     break;

--- a/src/clientagent/Client.h
+++ b/src/clientagent/Client.h
@@ -231,7 +231,8 @@ class Client : public MDParticipantInterface
     // to m_remote from Client
     virtual const std::string get_remote_address() = 0;
     virtual uint16_t get_remote_port() = 0;
-    virtual const tcp::socket* get_socket() = 0;
+    virtual const std::string get_local_address() = 0;
+    virtual uint16_t get_local_port() = 0;
 
   private:
     // notify_interest_done send a CLIENTAGENT_DONE_INTEREST_RESP to the

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -9,6 +9,11 @@ MDNetworkParticipant::MDNetworkParticipant(boost::asio::ip::tcp::socket *socket)
     set_con_name("Network Participant");
 }
 
+MDNetworkParticipant::~MDNetworkParticipant()
+{
+    m_client.disconnect();
+}
+
 void MDNetworkParticipant::handle_datagram(DatagramHandle dg, DatagramIterator&)
 {
     logger().trace() << "MDNetworkParticipant sending to downstream MD" << std::endl;

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -81,7 +81,7 @@ void MDNetworkParticipant::receive_datagram(DatagramHandle dg)
 void MDNetworkParticipant::receive_disconnect(const boost::system::error_code &ec)
 {
     logger().info() << "Lost connection from "
-                    << m_remote.address() << ":" << m_remote.port() << ": "
+                    << get_remote().address() << ":" << get_remote().port() << ": "
                     << ec.message() << std::endl;
     terminate();
 }

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -4,9 +4,11 @@
 #include <boost/bind.hpp>
 
 MDNetworkParticipant::MDNetworkParticipant(boost::asio::ip::tcp::socket *socket)
-    : MDParticipantInterface(), m_client(this, socket)
+    : MDParticipantInterface(), m_client(this)
 {
     set_con_name("Network Participant");
+
+    m_client.set_socket(socket);
 }
 
 MDNetworkParticipant::~MDNetworkParticipant()

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -4,7 +4,7 @@
 #include <boost/bind.hpp>
 
 MDNetworkParticipant::MDNetworkParticipant(boost::asio::ip::tcp::socket *socket)
-    : MDParticipantInterface(), NetworkClient(socket)
+    : MDParticipantInterface(), m_client(this, socket)
 {
     set_con_name("Network Participant");
 }
@@ -13,7 +13,7 @@ void MDNetworkParticipant::handle_datagram(DatagramHandle dg, DatagramIterator&)
 {
     logger().trace() << "MDNetworkParticipant sending to downstream MD" << std::endl;
     try {
-        send_datagram(dg);
+        m_client.send_datagram(dg);
     } catch(const boost::system::system_error &) {
         logger().warning() << "Received a system error while sending a datagram to a network "
                            "participant (the participant may have lost connection)." << std::endl;
@@ -81,7 +81,8 @@ void MDNetworkParticipant::receive_datagram(DatagramHandle dg)
 void MDNetworkParticipant::receive_disconnect(const boost::system::error_code &ec)
 {
     logger().info() << "Lost connection from "
-                    << get_remote().address() << ":" << get_remote().port() << ": "
+                    << m_client.get_remote().address() << ":"
+		    << m_client.get_remote().port() << ": "
                     << ec.message() << std::endl;
     terminate();
 }

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -4,23 +4,23 @@
 #include <boost/bind.hpp>
 
 MDNetworkParticipant::MDNetworkParticipant(boost::asio::ip::tcp::socket *socket)
-    : MDParticipantInterface(), m_client(this)
+    : MDParticipantInterface(), m_client(std::make_shared<NetworkClient>(this))
 {
     set_con_name("Network Participant");
 
-    m_client.set_socket(socket);
+    m_client->set_socket(socket);
 }
 
 MDNetworkParticipant::~MDNetworkParticipant()
 {
-    m_client.disconnect();
+    m_client->disconnect();
 }
 
 void MDNetworkParticipant::handle_datagram(DatagramHandle dg, DatagramIterator&)
 {
     logger().trace() << "MDNetworkParticipant sending to downstream MD" << std::endl;
     try {
-        m_client.send_datagram(dg);
+        m_client->send_datagram(dg);
     } catch(const boost::system::system_error &) {
         logger().warning() << "Received a system error while sending a datagram to a network "
                            "participant (the participant may have lost connection)." << std::endl;
@@ -88,8 +88,8 @@ void MDNetworkParticipant::receive_datagram(DatagramHandle dg)
 void MDNetworkParticipant::receive_disconnect(const boost::system::error_code &ec)
 {
     logger().info() << "Lost connection from "
-                    << m_client.get_remote().address() << ":"
-		    << m_client.get_remote().port() << ": "
+                    << m_client->get_remote().address() << ":"
+		    << m_client->get_remote().port() << ": "
                     << ec.message() << std::endl;
     terminate();
 }

--- a/src/messagedirector/MDNetworkParticipant.h
+++ b/src/messagedirector/MDNetworkParticipant.h
@@ -2,7 +2,7 @@
 #include "MessageDirector.h"
 #include "net/NetworkClient.h"
 
-class MDNetworkParticipant : public MDParticipantInterface, public NetworkClient
+class MDNetworkParticipant : public MDParticipantInterface, public NetworkHandler
 {
   public:
     MDNetworkParticipant(boost::asio::ip::tcp::socket *socket);
@@ -10,4 +10,6 @@ class MDNetworkParticipant : public MDParticipantInterface, public NetworkClient
   private:
     virtual void receive_datagram(DatagramHandle dg);
     virtual void receive_disconnect(const boost::system::error_code &ec);
+
+    NetworkClient m_client;
 };

--- a/src/messagedirector/MDNetworkParticipant.h
+++ b/src/messagedirector/MDNetworkParticipant.h
@@ -12,5 +12,5 @@ class MDNetworkParticipant : public MDParticipantInterface, public NetworkHandle
     virtual void receive_datagram(DatagramHandle dg);
     virtual void receive_disconnect(const boost::system::error_code &ec);
 
-    NetworkClient m_client;
+    std::shared_ptr<NetworkClient> m_client;
 };

--- a/src/messagedirector/MDNetworkParticipant.h
+++ b/src/messagedirector/MDNetworkParticipant.h
@@ -6,6 +6,7 @@ class MDNetworkParticipant : public MDParticipantInterface, public NetworkHandle
 {
   public:
     MDNetworkParticipant(boost::asio::ip::tcp::socket *socket);
+    ~MDNetworkParticipant();
     virtual void handle_datagram(DatagramHandle dg, DatagramIterator &dgi);
   private:
     virtual void receive_datagram(DatagramHandle dg);

--- a/src/messagedirector/MDNetworkUpstream.cpp
+++ b/src/messagedirector/MDNetworkUpstream.cpp
@@ -7,7 +7,7 @@
 using boost::asio::ip::tcp;
 
 MDNetworkUpstream::MDNetworkUpstream(MessageDirector *md) :
-    m_message_director(md)
+    m_message_director(md), m_client(this)
 {
 
 }
@@ -19,7 +19,7 @@ boost::system::error_code MDNetworkUpstream::connect(const std::string &address)
     tcp::socket *socket = connector.connect(address, 7199, ec);
 
     if(socket) {
-        set_socket(socket);
+        m_client.set_socket(socket);
     }
 
     return ec;
@@ -29,14 +29,14 @@ void MDNetworkUpstream::subscribe_channel(channel_t c)
 {
     DatagramPtr dg = Datagram::create(CONTROL_ADD_CHANNEL);
     dg->add_channel(c);
-    send_datagram(dg);
+    m_client.send_datagram(dg);
 }
 
 void MDNetworkUpstream::unsubscribe_channel(channel_t c)
 {
     DatagramPtr dg = Datagram::create(CONTROL_REMOVE_CHANNEL);
     dg->add_channel(c);
-    send_datagram(dg);
+    m_client.send_datagram(dg);
 }
 
 void MDNetworkUpstream::subscribe_range(channel_t lo, channel_t hi)
@@ -44,7 +44,7 @@ void MDNetworkUpstream::subscribe_range(channel_t lo, channel_t hi)
     DatagramPtr dg = Datagram::create(CONTROL_ADD_RANGE);
     dg->add_channel(lo);
     dg->add_channel(hi);
-    send_datagram(dg);
+    m_client.send_datagram(dg);
 }
 
 void MDNetworkUpstream::unsubscribe_range(channel_t lo, channel_t hi)
@@ -52,12 +52,12 @@ void MDNetworkUpstream::unsubscribe_range(channel_t lo, channel_t hi)
     DatagramPtr dg = Datagram::create(CONTROL_REMOVE_RANGE);
     dg->add_channel(lo);
     dg->add_channel(hi);
-    send_datagram(dg);
+    m_client.send_datagram(dg);
 }
 
 void MDNetworkUpstream::handle_datagram(DatagramHandle dg)
 {
-    send_datagram(dg);
+    m_client.send_datagram(dg);
 }
 
 void MDNetworkUpstream::receive_datagram(DatagramHandle dg)

--- a/src/messagedirector/MDNetworkUpstream.cpp
+++ b/src/messagedirector/MDNetworkUpstream.cpp
@@ -7,7 +7,7 @@
 using boost::asio::ip::tcp;
 
 MDNetworkUpstream::MDNetworkUpstream(MessageDirector *md) :
-    m_message_director(md), m_client(this)
+    m_message_director(md), m_client(std::make_shared<NetworkClient>(this))
 {
 
 }
@@ -19,7 +19,7 @@ boost::system::error_code MDNetworkUpstream::connect(const std::string &address)
     tcp::socket *socket = connector.connect(address, 7199, ec);
 
     if(socket) {
-        m_client.set_socket(socket);
+        m_client->set_socket(socket);
     }
 
     return ec;
@@ -29,14 +29,14 @@ void MDNetworkUpstream::subscribe_channel(channel_t c)
 {
     DatagramPtr dg = Datagram::create(CONTROL_ADD_CHANNEL);
     dg->add_channel(c);
-    m_client.send_datagram(dg);
+    m_client->send_datagram(dg);
 }
 
 void MDNetworkUpstream::unsubscribe_channel(channel_t c)
 {
     DatagramPtr dg = Datagram::create(CONTROL_REMOVE_CHANNEL);
     dg->add_channel(c);
-    m_client.send_datagram(dg);
+    m_client->send_datagram(dg);
 }
 
 void MDNetworkUpstream::subscribe_range(channel_t lo, channel_t hi)
@@ -44,7 +44,7 @@ void MDNetworkUpstream::subscribe_range(channel_t lo, channel_t hi)
     DatagramPtr dg = Datagram::create(CONTROL_ADD_RANGE);
     dg->add_channel(lo);
     dg->add_channel(hi);
-    m_client.send_datagram(dg);
+    m_client->send_datagram(dg);
 }
 
 void MDNetworkUpstream::unsubscribe_range(channel_t lo, channel_t hi)
@@ -52,12 +52,12 @@ void MDNetworkUpstream::unsubscribe_range(channel_t lo, channel_t hi)
     DatagramPtr dg = Datagram::create(CONTROL_REMOVE_RANGE);
     dg->add_channel(lo);
     dg->add_channel(hi);
-    m_client.send_datagram(dg);
+    m_client->send_datagram(dg);
 }
 
 void MDNetworkUpstream::handle_datagram(DatagramHandle dg)
 {
-    m_client.send_datagram(dg);
+    m_client->send_datagram(dg);
 }
 
 void MDNetworkUpstream::receive_datagram(DatagramHandle dg)

--- a/src/messagedirector/MDNetworkUpstream.h
+++ b/src/messagedirector/MDNetworkUpstream.h
@@ -6,7 +6,7 @@
 // All MDUpstreams must be thread-safe. This class does not need a lock, however,
 // because all of its operations are based on local variables and the functions
 // of NetworkClient (which are themselves thread-safe)
-class MDNetworkUpstream : public NetworkClient, public MDUpstream
+class MDNetworkUpstream : public NetworkHandler, public MDUpstream
 {
   public:
     MDNetworkUpstream(MessageDirector *md);
@@ -26,4 +26,5 @@ class MDNetworkUpstream : public NetworkClient, public MDUpstream
 
   private:
     MessageDirector *m_message_director;
+    NetworkClient m_client;
 };

--- a/src/messagedirector/MDNetworkUpstream.h
+++ b/src/messagedirector/MDNetworkUpstream.h
@@ -26,5 +26,5 @@ class MDNetworkUpstream : public NetworkHandler, public MDUpstream
 
   private:
     MessageDirector *m_message_director;
-    NetworkClient m_client;
+    std::shared_ptr<NetworkClient> m_client;
 };

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -10,18 +10,6 @@ NetworkClient::NetworkClient(NetworkHandler *handler) : m_handler(handler), m_so
 {
 }
 
-NetworkClient::NetworkClient(NetworkHandler *handler, tcp::socket *socket) : m_handler(handler), m_socket(socket), m_secure_socket(nullptr),
-    m_ssl_enabled(false)
-{
-    start_receive();
-}
-
-NetworkClient::NetworkClient(NetworkHandler *handler, ssl::stream<tcp::socket>* stream) :
-    m_handler(handler), m_socket(&stream->next_layer()), m_secure_socket(stream), m_ssl_enabled(true)
-{
-    start_receive();
-}
-
 NetworkClient::~NetworkClient()
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -70,6 +70,7 @@ void NetworkClient::start_receive()
 {
     try {
         m_remote = m_socket->remote_endpoint();
+        m_local = m_socket->local_endpoint();
     } catch(const boost::system::system_error&) {
         // A client might disconnect immediately after connecting.
         // Since we are in the constructor, ignore it. Resolves #122.

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -25,6 +25,7 @@ NetworkClient::NetworkClient(NetworkHandler *handler, ssl::stream<tcp::socket>* 
 NetworkClient::~NetworkClient()
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
+    assert(!is_connected());
     if(m_ssl_enabled) {
         // This also deletes m_socket:
         delete m_secure_socket;
@@ -134,8 +135,11 @@ void NetworkClient::handle_disconnect(const boost::system::error_code &ec)
     if(m_disconnect_handled) {
         return;
     }
-
     m_disconnect_handled = true;
+
+    if(is_connected()) {
+        m_socket->close();
+    }
 
     if(m_local_disconnect) {
         m_handler->receive_disconnect(m_disconnect_error);

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -190,12 +190,12 @@ void NetworkClient::socket_read(uint8_t* buf, size_t length, receive_handler_t c
 {
     if(m_ssl_enabled) {
         async_read(*m_secure_socket, boost::asio::buffer(buf, length),
-                   boost::bind(callback, this,
+                   boost::bind(callback, shared_from_this(),
                                boost::asio::placeholders::error,
                                boost::asio::placeholders::bytes_transferred));
     } else {
         async_read(*m_socket, boost::asio::buffer(buf, length),
-                   boost::bind(callback, this,
+                   boost::bind(callback, shared_from_this(),
                                boost::asio::placeholders::error,
                                boost::asio::placeholders::bytes_transferred));
     }

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -92,7 +92,7 @@ void NetworkClient::async_receive()
     } catch(const boost::system::system_error &err) {
         // An exception happening when trying to initiate a read is a clear
         // indicator that something happened to the connection. Therefore:
-        send_disconnect(err.code());
+        disconnect(err.code());
     }
 }
 
@@ -111,17 +111,17 @@ void NetworkClient::send_datagram(DatagramHandle dg)
     } catch(const boost::system::system_error &err) {
         // We assume that the message just got dropped if the remote end died
         // before we could send it.
-        send_disconnect(err.code());
+        disconnect(err.code());
     }
 }
 
-void NetworkClient::send_disconnect()
+void NetworkClient::disconnect()
 {
     boost::system::error_code ec;
-    send_disconnect(ec);
+    disconnect(ec);
 }
 
-void NetworkClient::send_disconnect(const boost::system::error_code &ec)
+void NetworkClient::disconnect(const boost::system::error_code &ec)
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
     m_local_disconnect = true;

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -6,18 +6,18 @@
 using boost::asio::ip::tcp;
 namespace ssl = boost::asio::ssl;
 
-NetworkClient::NetworkClient() : m_socket(nullptr), m_secure_socket(nullptr), m_ssl_enabled(false)
+NetworkClient::NetworkClient(NetworkHandler *handler) : m_handler(handler), m_socket(nullptr), m_secure_socket(nullptr), m_ssl_enabled(false)
 {
 }
 
-NetworkClient::NetworkClient(tcp::socket *socket) : m_socket(socket), m_secure_socket(nullptr),
+NetworkClient::NetworkClient(NetworkHandler *handler, tcp::socket *socket) : m_handler(handler), m_socket(socket), m_secure_socket(nullptr),
     m_ssl_enabled(false)
 {
     start_receive();
 }
 
-NetworkClient::NetworkClient(ssl::stream<tcp::socket>* stream) :
-    m_socket(&stream->next_layer()), m_secure_socket(stream), m_ssl_enabled(true)
+NetworkClient::NetworkClient(NetworkHandler *handler, ssl::stream<tcp::socket>* stream) :
+    m_handler(handler), m_socket(&stream->next_layer()), m_secure_socket(stream), m_ssl_enabled(true)
 {
     start_receive();
 }
@@ -138,9 +138,9 @@ void NetworkClient::handle_disconnect(const boost::system::error_code &ec)
     m_disconnect_handled = true;
 
     if(m_local_disconnect) {
-        receive_disconnect(m_disconnect_error);
+        m_handler->receive_disconnect(m_disconnect_error);
     } else {
-        receive_disconnect(ec);
+        m_handler->receive_disconnect(ec);
     }
 }
 
@@ -184,7 +184,7 @@ void NetworkClient::receive_data(const boost::system::error_code &ec, size_t byt
 
     DatagramPtr dg = Datagram::create(m_data_buf, m_data_size); // Datagram makes a copy
     m_is_data = false;
-    receive_datagram(dg);
+    m_handler->receive_datagram(dg);
     async_receive();
 }
 

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -5,6 +5,16 @@
 #include <boost/asio/ssl.hpp>
 #include "util/Datagram.h"
 
+// NOTES:
+//
+// Do not subclass NetworkClient. Instead, you should implement NetworkHandler
+// and instantiate NetworkClient with std::make_shared.
+//
+// To begin receiving, pass it an ASIO socket or SSL stream via set_socket.
+//
+// You must not destruct your NetworkHandler implementor until
+// receive_disconnect is called!
+
 class NetworkClient;
 
 class NetworkHandler
@@ -15,6 +25,9 @@ class NetworkHandler
     virtual void receive_datagram(DatagramHandle dg) = 0;
     // receive_disconnect is called when the remote host closes the
     //     connection or otherwise when the tcp connection is lost.
+    //
+    // NOTE: Your handler pointer must remain valid until this function is
+    //     called, indicating that the NetworkClient has cleaned up.
     virtual void receive_disconnect(const boost::system::error_code &ec) = 0;
 
     friend class NetworkClient;

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -16,6 +16,8 @@ class NetworkClient
     // is_connected returns true if the TCP connection is active, or false otherwise
     bool is_connected();
 
+    inline boost::asio::ip::tcp::endpoint get_remote() { return m_remote; }
+
   protected:
     NetworkClient();
     NetworkClient(boost::asio::ip::tcp::socket *socket);
@@ -53,7 +55,6 @@ class NetworkClient
 
     boost::asio::ip::tcp::socket *m_socket;
     boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *m_secure_socket;
-    boost::asio::ip::tcp::endpoint m_remote;
 
   private:
     typedef void (NetworkClient::*receive_handler_t)(const boost::system::error_code&, size_t);
@@ -63,6 +64,7 @@ class NetworkClient
 
     void handle_disconnect(const boost::system::error_code &ec);
 
+    boost::asio::ip::tcp::endpoint m_remote;
     bool m_ssl_enabled;
     bool m_disconnect_handled = false;
     bool m_local_disconnect = false;

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -5,31 +5,11 @@
 #include <boost/asio/ssl.hpp>
 #include "util/Datagram.h"
 
-class NetworkClient
+class NetworkClient;
+
+class NetworkHandler
 {
-  public:
-    // send_datagram immediately sends the datagram over TCP (blocking).
-    virtual void send_datagram(DatagramHandle dg);
-    // send_disconnect closes the TCP connection
-    virtual void send_disconnect();
-    virtual void send_disconnect(const boost::system::error_code &ec);
-    // is_connected returns true if the TCP connection is active, or false otherwise
-    bool is_connected();
-
-    inline boost::asio::ip::tcp::endpoint get_remote() { return m_remote; }
-    inline boost::asio::ip::tcp::endpoint get_local() { return m_local; }
-
   protected:
-    NetworkClient();
-    NetworkClient(boost::asio::ip::tcp::socket *socket);
-    NetworkClient(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
-    virtual ~NetworkClient();
-    void set_socket(boost::asio::ip::tcp::socket *socket);
-    void set_socket(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
-
-
-    /** Pure virtual methods **/
-
     // receive_datagram is called when both a datagram's size and its data
     //     have been received asynchronously from the network.
     virtual void receive_datagram(DatagramHandle dg) = 0;
@@ -37,27 +17,51 @@ class NetworkClient
     //     connection or otherwise when the tcp connection is lost.
     virtual void receive_disconnect(const boost::system::error_code &ec) = 0;
 
+    friend class NetworkClient;
+};
 
+class NetworkClient
+{
+  public:
+    NetworkClient(NetworkHandler *handler);
+    NetworkClient(NetworkHandler *handler, boost::asio::ip::tcp::socket *socket);
+    NetworkClient(NetworkHandler *handler, boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+    ~NetworkClient();
+
+    void set_socket(boost::asio::ip::tcp::socket *socket);
+    void set_socket(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+
+    // send_datagram immediately sends the datagram over TCP (blocking).
+    void send_datagram(DatagramHandle dg);
+    // disconnect closes the TCP connection
+    void send_disconnect();
+    void send_disconnect(const boost::system::error_code &ec);
+    // is_connected returns true if the TCP connection is active, or false otherwise
+    bool is_connected();
+
+    inline boost::asio::ip::tcp::endpoint get_remote() { return m_remote; }
+    inline boost::asio::ip::tcp::endpoint get_local() { return m_local; }
+
+  private:
     /* Asynchronous call loop */
 
     // start_receive is called by the constructor or set_socket
     //     after m_socket is set to a provided socket.
-    virtual void start_receive();
+    void start_receive();
 
     // async_receive is called by start_receive to begin receiving data, then by receive_size
     //     or receive_data to wait for the next set of data.
-    virtual void async_receive();
+    void async_receive();
 
     // receive_size is called by async_receive when receiving the datagram size
-    virtual void receive_size(const boost::system::error_code &ec, size_t bytes_transferred);
+    void receive_size(const boost::system::error_code &ec, size_t bytes_transferred);
     // receive_data is called by async_receive when receiving the datagram data
-    virtual void receive_data(const boost::system::error_code &ec, size_t bytes_transferred);
+    void receive_data(const boost::system::error_code &ec, size_t bytes_transferred);
 
 
     boost::asio::ip::tcp::socket *m_socket;
     boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *m_secure_socket;
 
-  private:
     typedef void (NetworkClient::*receive_handler_t)(const boost::system::error_code&, size_t);
 
     void socket_read(uint8_t* buf, size_t length, receive_handler_t callback);
@@ -65,6 +69,7 @@ class NetworkClient
 
     void handle_disconnect(const boost::system::error_code &ec);
 
+    NetworkHandler *m_handler;
     boost::asio::ip::tcp::endpoint m_remote;
     boost::asio::ip::tcp::endpoint m_local;
     bool m_ssl_enabled;

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -24,8 +24,6 @@ class NetworkClient
 {
   public:
     NetworkClient(NetworkHandler *handler);
-    NetworkClient(NetworkHandler *handler, boost::asio::ip::tcp::socket *socket);
-    NetworkClient(NetworkHandler *handler, boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
     ~NetworkClient();
 
     void set_socket(boost::asio::ip::tcp::socket *socket);

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -20,7 +20,7 @@ class NetworkHandler
     friend class NetworkClient;
 };
 
-class NetworkClient
+class NetworkClient : public std::enable_shared_from_this<NetworkClient>
 {
   public:
     NetworkClient(NetworkHandler *handler);

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -34,8 +34,8 @@ class NetworkClient
     // send_datagram immediately sends the datagram over TCP (blocking).
     void send_datagram(DatagramHandle dg);
     // disconnect closes the TCP connection
-    void send_disconnect();
-    void send_disconnect(const boost::system::error_code &ec);
+    void disconnect();
+    void disconnect(const boost::system::error_code &ec);
     // is_connected returns true if the TCP connection is active, or false otherwise
     bool is_connected();
 

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -17,6 +17,7 @@ class NetworkClient
     bool is_connected();
 
     inline boost::asio::ip::tcp::endpoint get_remote() { return m_remote; }
+    inline boost::asio::ip::tcp::endpoint get_local() { return m_local; }
 
   protected:
     NetworkClient();
@@ -65,6 +66,7 @@ class NetworkClient
     void handle_disconnect(const boost::system::error_code &ec);
 
     boost::asio::ip::tcp::endpoint m_remote;
+    boost::asio::ip::tcp::endpoint m_local;
     bool m_ssl_enabled;
     bool m_disconnect_handled = false;
     bool m_local_disconnect = false;


### PR DESCRIPTION
This PR changes `NetworkClient` so that you no longer subclass it. Instead, you subclass a new `NetworkHandler` type and pass it to the `NetworkClient` on creation; this is how callbacks are delivered.

Further, some stricter lifecycle changes have been made. It's an explicit error to allow the `NetworkClient` to destruct without disconnecting it first, and the appropriate way to use `NetworkClient` is always through a shared smart pointer, to ensure that the `NetworkClient` object stays valid until all callbacks finish.

There are also some small cleanups here and there - for example, `send_disconnect` is just `disconnect` now.