### PR TITLE
Fix race condition when Timeout is canceled from a separate thread.

### DIFF
--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -203,6 +203,10 @@ class AstronClient : public Client, public NetworkClient
             log_event(event);
         }
 
+        if(m_heartbeat_timer != nullptr) {
+            m_heartbeat_timer->cancel();
+        }
+
         annihilate();
     }
 

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -52,7 +52,7 @@ class AstronClient : public Client, public NetworkClient
 
     //Heartbeat
     long m_heartbeat_timeout;
-    Timeout *m_heartbeat_timer = nullptr;
+    std::shared_ptr<Timeout> m_heartbeat_timer = nullptr;
 
   public:
     AstronClient(ConfigNode config, ClientAgent* client_agent, tcp::socket *socket) :
@@ -76,13 +76,6 @@ class AstronClient : public Client, public NetworkClient
         initialize();
     }
 
-    ~AstronClient()
-    {
-        if(m_heartbeat_timer != nullptr) {
-            delete m_heartbeat_timer;
-        }
-    }
-
     void heartbeat_timeout()
     {
         lock_guard<recursive_mutex> lock(m_client_lock);
@@ -94,8 +87,9 @@ class AstronClient : public Client, public NetworkClient
     {
         //If heartbeat, start the heartbeat timer now.
         if(m_heartbeat_timeout != 0) {
-            m_heartbeat_timer = new Timeout(m_heartbeat_timeout, std::bind(&AstronClient::heartbeat_timeout,
+            m_heartbeat_timer = std::make_shared<Timeout>(m_heartbeat_timeout, std::bind(&AstronClient::heartbeat_timeout,
                                             this));
+            m_heartbeat_timer->start();
         }
 
         // Set interest permissions

--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -767,6 +767,13 @@ InterestOperation::InterestOperation(
     m_timeout->start();
 }
 
+InterestOperation::~InterestOperation()
+{
+    bool canceled = m_timeout->cancel();
+
+    assert(m_finished || canceled);
+}
+
 void InterestOperation::timeout()
 {
     lock_guard<recursive_mutex> lock(m_client->m_client_lock);
@@ -813,6 +820,8 @@ void InterestOperation::finish(bool is_timeout)
         dgi.seek_payload();
         m_client->handle_datagram(*it, dgi);
     }
+
+    m_finished = true;
 
     delete this;
 }

--- a/src/clientagent/Client.h
+++ b/src/clientagent/Client.h
@@ -71,6 +71,7 @@ class InterestOperation
     InterestOperation(Client *client, unsigned long timeout,
                       uint16_t interest_id, uint32_t client_context, uint32_t request_context,
                       doid_t parent, std::unordered_set<zone_t> zones, channel_t caller);
+    ~InterestOperation();
 
     bool is_ready();
     void set_expected(doid_t total);
@@ -78,6 +79,9 @@ class InterestOperation
     void queue_datagram(DatagramHandle dg);
     void finish(bool is_timeout=false);
     void timeout();
+
+  private:
+    bool m_finished = false;
 };
 
 class Client : public MDParticipantInterface

--- a/src/clientagent/Client.h
+++ b/src/clientagent/Client.h
@@ -60,7 +60,7 @@ class InterestOperation
     std::unordered_set<zone_t> m_zones;
     std::set<channel_t> m_callers;
 
-    Timeout m_timeout;
+    std::shared_ptr<Timeout> m_timeout;
 
     bool m_has_total = false;
     doid_t m_total = 0; // as doid_t because <max_objs_in_zones> == <max_total_objs>
@@ -76,7 +76,7 @@ class InterestOperation
     void set_expected(doid_t total);
     void queue_expected(DatagramHandle dg);
     void queue_datagram(DatagramHandle dg);
-    void finish();
+    void finish(bool is_timeout=false);
     void timeout();
 };
 

--- a/src/util/Timeout.cpp
+++ b/src/util/Timeout.cpp
@@ -6,16 +6,19 @@
 Timeout::Timeout(unsigned long ms, std::function<void()> f) :
     m_timer(io_service, boost::posix_time::milliseconds(ms)),
     m_callback(f),
-    m_timeout_interval(ms)
+    m_timeout_interval(ms),
+    m_callback_disabled(false)
 {
-    m_timer.async_wait(boost::bind(&Timeout::timer_callback, this,
-                boost::asio::placeholders::error));
 }
 
 void Timeout::timer_callback(const boost::system::error_code &ec)
 {
     if(ec) {
         return; // We were canceled.
+    }
+
+    if(m_callback_disabled.exchange(true)) {
+        return; // Stop m_callback running twice or after successful cancel().
     }
 
     m_callback();
@@ -25,11 +28,17 @@ void Timeout::reset()
 {
     m_timer.cancel();
     m_timer.expires_from_now(boost::posix_time::millisec(m_timeout_interval));
-    m_timer.async_wait(boost::bind(&Timeout::timer_callback, this,
+    m_timer.async_wait(boost::bind(&Timeout::timer_callback, shared_from_this(),
                                    boost::asio::placeholders::error));
+}
+
+bool Timeout::cancel()
+{
+    m_timer.cancel();
+    return !m_callback_disabled.exchange(true);
 }
 
 Timeout::~Timeout()
 {
-    m_timer.cancel();
+    assert(m_callback_disabled.load());
 }

--- a/src/util/Timeout.h
+++ b/src/util/Timeout.h
@@ -4,23 +4,34 @@
 
 // This class abstracts the boost::asio timer in order to provide a generic
 // facility for timeouts. Once constructed, this class will wait a certain
-// amount of time and then call the function. The timeout is automatically
-// canceled when this class is destructed.
+// amount of time and then call the function. The timeout must be canceled
+// with cancel() before you invalidate your callback.
+//
+// You must start the timeout with start().
 //
 // NOTE: The thread that calls the function is undefined. Ensure that your
 // callback is thread-safe.
-class Timeout
+class Timeout : public std::enable_shared_from_this<Timeout>
 {
   public:
     Timeout(unsigned long ms, std::function<void()> f);
-    virtual ~Timeout();
+    ~Timeout();
+    inline void start() { reset(); }
     void reset();
+    // cancel() attempts to invalidate the callback and ensure that it will not
+    // run. On success, returns true, guaranteeing that the callback has/will
+    // not be triggered. On failure, returns false, indicating either that the
+    // callback was already canceled, the callback has already finished
+    // running, or the callback is (about to be) called.
+    bool cancel();
     
 
   private:
     boost::asio::deadline_timer m_timer;
     std::function<void()> m_callback;
     long m_timeout_interval;
+
+    std::atomic<bool> m_callback_disabled;
     
     void timer_callback(const boost::system::error_code &ec);
 };


### PR DESCRIPTION
This involves converting Timeout to an object counted with shared pointers
(so that the ASIO callback can function correctly even after the Timeout
object itself is dereferenced by its parent object) and requiring an
explicit cancel.

In particular, InterestOperation explicitly cancels and only bothers
cleaning up manually if the cancelation fails.