### PR TITLE
SSL handshake timeout

### DIFF
--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -29,6 +29,7 @@ static ConfigVariable<unsigned int> tls_verify_depth("max_verify_depth", 6, tls_
 static ConfigVariable<bool> sslv2_enabled("sslv2", false, tls_config);
 static ConfigVariable<bool> sslv3_enabled("sslv3", false, tls_config);
 static ConfigVariable<bool> tlsv1_enabled("tlsv1", true, tls_config);
+static ConfigVariable<int> tls_handshake_timeout("handshake_timeout", 5000, tls_config);
 static FileAvailableConstraint tls_cert_exists(tls_cert);
 static FileAvailableConstraint tls_key_exists(tls_key);
 static FileAvailableConstraint tls_chain_exists(tls_chain);
@@ -180,7 +181,12 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
 
         SslAcceptorCallback callback = std::bind(&ClientAgent::handle_ssl,
                                        this, std::placeholders::_1);
-        m_net_acceptor = new SslAcceptor(io_service, m_ssl_ctx, callback);
+        auto ssl_acceptor = new SslAcceptor(io_service, m_ssl_ctx, callback);
+
+        // Set SSL handshake timeout.
+        ssl_acceptor->set_handshake_timeout(tls_handshake_timeout.get_rval(tls_settings));
+
+	m_net_acceptor = ssl_acceptor;
     }
 
     // Begin listening for new Clients

--- a/src/net/SslAcceptor.cpp
+++ b/src/net/SslAcceptor.cpp
@@ -40,7 +40,9 @@ void SslAcceptor::handle_accept(ssl::stream<tcp::socket> *socket,
                             boost::bind(&SslAcceptor::handle_handshake, this,
                                         socket, timeout,
                                         boost::asio::placeholders::error));
-    timeout->start();
+    if(m_handshake_timeout > 0) {
+        timeout->start();
+    }
 
     // Start accepting again:
     start_accept();

--- a/src/net/SslAcceptor.cpp
+++ b/src/net/SslAcceptor.cpp
@@ -44,6 +44,12 @@ void SslAcceptor::handle_accept(ssl::stream<tcp::socket> *socket,
 void SslAcceptor::handle_handshake(ssl::stream<tcp::socket> *socket,
                                    const boost::system::error_code &ec)
 {
+    if(!m_started) {
+        // We were turned off sometime before this operation completed; ignore.
+        delete socket;
+        return;
+    }
+
     if(ec.value() != 0) {
         // The handshake failed for some reason. Free the socket and try again:
         delete socket;

--- a/src/net/SslAcceptor.h
+++ b/src/net/SslAcceptor.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "NetworkAcceptor.h"
+#include "util/Timeout.h"
 #include <functional>
 #include <boost/asio/ssl.hpp>
 namespace ssl = boost::asio::ssl;
@@ -17,7 +18,10 @@ class SslAcceptor : public NetworkAcceptor
     ssl::context& m_context;
     SslAcceptorCallback m_callback;
 
+    int m_handshake_timeout = 5000; // This might be tweakable in the future.
+
     virtual void start_accept();
     void handle_accept(ssl::stream<tcp::socket> *socket, const boost::system::error_code &ec);
-    void handle_handshake(ssl::stream<tcp::socket> *socket, const boost::system::error_code &ec);
+    void handle_handshake(ssl::stream<tcp::socket> *socket, std::shared_ptr<Timeout> timeout, const boost::system::error_code &ec);
+    void handle_timeout(ssl::stream<tcp::socket> *socket);
 };

--- a/src/net/SslAcceptor.h
+++ b/src/net/SslAcceptor.h
@@ -14,11 +14,13 @@ class SslAcceptor : public NetworkAcceptor
                 SslAcceptorCallback &callback);
     virtual ~SslAcceptor() {}
 
+    inline void set_handshake_timeout(int milliseconds) { m_handshake_timeout = milliseconds; }
+
   private:
     ssl::context& m_context;
     SslAcceptorCallback m_callback;
 
-    int m_handshake_timeout = 5000; // This might be tweakable in the future.
+    int m_handshake_timeout = 0;
 
     virtual void start_accept();
     void handle_accept(ssl::stream<tcp::socket> *socket, const boost::system::error_code &ec);

--- a/test/test_clientagent.py
+++ b/test/test_clientagent.py
@@ -64,6 +64,7 @@ roles:
       tls:
           certificate: %r
           key_file: %r
+          handshake_timeout: 200
 
     - type: clientagent
       bind: 127.0.0.1:51201
@@ -3010,6 +3011,12 @@ class TestClientAgent(ProtocolTest):
         tls_context = {'ssl_version': ssl.PROTOCOL_TLSv1}
         client = self.connect(port = 57214, tls_opts = tls_context)
         id = self.identify(client, min = 330600, max = 330699)
+
+    def test_ssl_tls_timeout(self):
+        client = self.connect(port = 57214, do_hello=False)
+        self.expectNone(client)
+        time.sleep(0.2)
+        self.assertRaises(EOFError, client.recv_maybe)
 
     def test_get_network_address(self):
         self.server.flush()


### PR DESCRIPTION
This adds a 5000ms timeout for newly-connecting clients to issue an SSL handshake before the server closes the connection.

Without this, clients may sometimes connect and, before performing the handshake, silently lose their connection (i.e. no TCP RST/FIN, due to e.g. power loss). With no traffic, the TCP connection will never time out from a missing ACK, and with the server waiting indefinitely for an SSL handshake, no traffic is ever sent.

Comments welcome as to whether 5000ms is a good number, whether it should be configurable, higher, lower, etc.