### PR TITLE
Use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+dist: trusty
+sudo: required
+
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+
+addons:
+  apt:
+    packages:
+    - cmake
+    - libboost-filesystem-dev
+    - libboost-regex-dev
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libssl-dev
+    - libyaml-cpp-dev
+
+script: make build && cd build && cmake .. && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ addons:
     - libssl-dev
     - libyaml-cpp-dev
 
-script: make build && cd build && cmake .. && make && make test
+script: mkdir build && cd build && cmake .. && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,8 @@ addons:
     - libssl-dev
     - libyaml-cpp-dev
 
+# Workaround for https://svn.boost.org/trac/boost/ticket/7473
+before_script:
+    -  'if [ "$CXX" == "clang++" ]; then sudo apt-get install wget && sudo wget -O /usr/include/boost/config/stdlib/libstdcpp3.hpp https://raw.githubusercontent.com/boostorg/config/b36566fe04a89103b7ef5569c03e3a26eb77af36/include/boost/config/stdlib/libstdcpp3.hpp; fi'
+
 script: mkdir build && cd build && cmake .. && make && env CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,7 @@ addons:
     - libssl-dev
     - libyaml-cpp-dev
 
+env:
+- CTEST_OUTPUT_ON_FAILURE=1
+
 script: mkdir build && cd build && cmake .. && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,4 @@ addons:
     - libssl-dev
     - libyaml-cpp-dev
 
-env:
-- CTEST_OUTPUT_ON_FAILURE=1
-
-script: mkdir build && cd build && cmake .. && make && make test
+script: mkdir build && cd build && cmake .. && make && env CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Group, and used in-house from 2001 until 2013.
 The suite consists of many components, which handle separate tasks in order to distribute
 the workload of managing a multi-sharded game/application environment with many objects and clients.
 
-[![build status](https://build.riotcave.com/projects/1/status.png?ref=master)](https://build.riotcave.com/projects/1?ref=master)
+[![Build Status](https://travis-ci.org/Astron/Astron.svg?branch=master)](https://travis-ci.org/Astron/Astron)
 
 ## Overview ##
 

--- a/src/util/Timeout.h
+++ b/src/util/Timeout.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <functional>
+#include <atomic>
+#include <memory>
 #include <boost/asio.hpp>
 
 // This class abstracts the boost::asio timer in order to provide a generic

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,6 +2,16 @@
 import unittest
 from common.unittests import ConfigTest
 from common.dcfile import *
+import socket
+
+def test_ipv6():
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.bind(('::1', 0))
+    except socket.error:
+        return False
+    else:
+        return True
 
 class TestConfigCore(ConfigTest):
     def test_core_good(self):
@@ -254,29 +264,35 @@ class TestConfigCore(ConfigTest):
         self.assertEquals(self.checkConfig(config), 'Invalid')
 
         # Some IPv6 cases...
+
+        # Note: These only work if the test runner has IPv6 support. Let's
+        # check:
+
+        has_ipv6 = test_ipv6()
+
         config = """\
             messagedirector:
                 bind: "::1"
             """
-        self.assertEquals(self.checkConfig(config), 'Valid')
+        if has_ipv6: self.assertEquals(self.checkConfig(config), 'Valid')
 
         config = """\
             messagedirector:
                 bind: "0:0:0:0:0:0:0:1"
             """
-        self.assertEquals(self.checkConfig(config), 'Valid')
+        if has_ipv6: self.assertEquals(self.checkConfig(config), 'Valid')
 
         config = """\
             messagedirector:
                 bind: "[0:0::1]"
             """
-        self.assertEquals(self.checkConfig(config), 'Valid')
+        if has_ipv6: self.assertEquals(self.checkConfig(config), 'Valid')
 
         config = """\
             messagedirector:
                 bind: "[0:0::1]:57123"
             """
-        self.assertEquals(self.checkConfig(config), 'Valid')
+        if has_ipv6: self.assertEquals(self.checkConfig(config), 'Valid')
 
         config = """\
             messagedirector:


### PR DESCRIPTION
This seems to be the hip trend on GitHub: add a `.travis.yml` and toggle on Travis-CI integration.

This PR mostly creates such a file, but also disables the IPv6 binding tests when the host has no IPv6 loopback (as seems to be the case with Travis's job runners).

MongoDB test support to come in a future PR.