### PR TITLE
Support HAProxy PROXY protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,8 @@ set(UTIL_FILES
 set(NET_FILES
 	src/net/address_utils.cpp
 	src/net/address_utils.h
+	src/net/HAProxyHandler.cpp
+	src/net/HAProxyHandler.h
 	src/net/NetworkAcceptor.cpp
 	src/net/NetworkAcceptor.h
 	src/net/NetworkClient.cpp

--- a/docs/config/astron.example.yml
+++ b/docs/config/astron.example.yml
@@ -52,6 +52,15 @@ roles:
       #manual_dc_hash: 0xABCD1234
       version: "FooGame v7.0"
 
+      # "haproxy" can be turned on to indicate that incoming connections will
+      # be prefixed with HAProxy's PROXY protocol, and the client address
+      # should be read from this instead.
+      #
+      # You should enable this if you are running your Astron CAs behind
+      # HAProxy. In your HAProxy config, you must also add either the
+      # "send-proxy-v2" (recommended) or the "send-proxy" option (not recommended).
+      #haproxy: true
+
       # TLS is an optional section (though it should ALWAYS be used in production)
       # It enables SSL/TLS, allowing you to configure a number of TLS options.
       tls:

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -56,7 +56,8 @@ class AstronClient : public Client, public NetworkHandler
     std::shared_ptr<Timeout> m_heartbeat_timer = nullptr;
 
   public:
-    AstronClient(ConfigNode config, ClientAgent* client_agent, tcp::socket *socket) :
+    AstronClient(ConfigNode config, ClientAgent* client_agent, tcp::socket *socket,
+                 const tcp::endpoint &remote, const tcp::endpoint &local) :
         Client(config, client_agent), m_client(std::make_shared<NetworkClient>(this)),
         m_config(config),
         m_clean_disconnect(false), m_relocate_owned(relocate_owned.get_rval(config)),
@@ -64,13 +65,14 @@ class AstronClient : public Client, public NetworkHandler
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
-        m_client->initialize(socket);
+        m_client->initialize(socket, remote, local);
 
         initialize();
     }
 
     AstronClient(ConfigNode config, ClientAgent* client_agent,
-                 ssl::stream<tcp::socket> *stream) :
+                 ssl::stream<tcp::socket> *stream,
+                 const tcp::endpoint &remote, const tcp::endpoint &local) :
         Client(config, client_agent), m_client(std::make_shared<NetworkClient>(this)),
         m_config(config),
         m_clean_disconnect(false), m_relocate_owned(relocate_owned.get_rval(config)),
@@ -78,7 +80,7 @@ class AstronClient : public Client, public NetworkHandler
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
-        m_client->initialize(stream);
+        m_client->initialize(stream, remote, local);
 
         initialize();
     }

--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -64,7 +64,7 @@ class AstronClient : public Client, public NetworkHandler
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
-        m_client->set_socket(socket);
+        m_client->initialize(socket);
 
         initialize();
     }
@@ -78,7 +78,7 @@ class AstronClient : public Client, public NetworkHandler
         m_send_version(send_version_to_client.get_rval(config)),
         m_heartbeat_timeout(heartbeat_timeout_config.get_rval(config))
     {
-        m_client->set_socket(stream);
+        m_client->initialize(stream);
 
         initialize();
     }

--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -17,6 +17,7 @@ namespace filesystem = boost::filesystem;
 RoleConfigGroup clientagent_config("clientagent");
 static ConfigVariable<string> bind_addr("bind", "0.0.0.0:7198", clientagent_config);
 static ConfigVariable<string> server_version("version", "dev", clientagent_config);
+static ConfigVariable<bool> behind_haproxy("haproxy", false, clientagent_config);
 static ConfigVariable<uint32_t> override_hash("manual_dc_hash", 0x0, clientagent_config);
 static ValidAddressConstraint valid_bind_addr(bind_addr);
 
@@ -186,6 +187,8 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
                                                  std::placeholders::_3);
         m_net_acceptor = new SslAcceptor(io_service, m_ssl_ctx, callback);
     }
+
+    m_net_acceptor->set_haproxy_mode(behind_haproxy.get_rval(m_roleconfig));
 
     // Begin listening for new Clients
     boost::system::error_code ec;

--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -100,9 +100,9 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
     if(m_ssl_cert.empty() && m_ssl_key.empty()) {
         m_log->debug() << "Not using SSL/TLS.\n";
         TcpAcceptorCallback callback = std::bind(&ClientAgent::handle_tcp, this,
-                                                 std::placeholders::_1,
-                                                 std::placeholders::_2,
-                                                 std::placeholders::_3);
+                                       std::placeholders::_1,
+                                       std::placeholders::_2,
+                                       std::placeholders::_3);
         m_net_acceptor = new TcpAcceptor(io_service, callback);
     }
 
@@ -173,9 +173,9 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
         }
 
         SslAcceptorCallback callback = std::bind(&ClientAgent::handle_ssl, this,
-                                                 std::placeholders::_1,
-                                                 std::placeholders::_2,
-                                                 std::placeholders::_3);
+                                       std::placeholders::_1,
+                                       std::placeholders::_2,
+                                       std::placeholders::_3);
         auto ssl_acceptor = new SslAcceptor(io_service, m_ssl_ctx, callback);
 
         // Set SSL handshake timeout.
@@ -215,7 +215,8 @@ void ClientAgent::handle_tcp(tcp::socket *socket,
     m_log->debug() << "Got an incoming connection from "
                    << remote.address() << ":" << remote.port() << "\n";
 
-    ClientFactory::singleton().instantiate_client(m_client_type, m_clientconfig, this, socket, remote, local);
+    ClientFactory::singleton().instantiate_client(m_client_type, m_clientconfig, this, socket, remote,
+            local);
 }
 
 // handle_ssl generates a new Client object from an ssl stream.
@@ -226,7 +227,8 @@ void ClientAgent::handle_ssl(ssl::stream<tcp::socket> *stream,
     m_log->debug() << "Got an incoming connection from "
                    << remote.address() << ":" << remote.port() << "\n";
 
-    ClientFactory::singleton().instantiate_client(m_client_type, m_clientconfig, this, stream, remote, local);
+    ClientFactory::singleton().instantiate_client(m_client_type, m_clientconfig, this, stream, remote,
+            local);
 }
 
 

--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -46,8 +46,6 @@ static InvalidChannelConstraint max_not_invalid(max_channel);
 static ReservedChannelConstraint min_not_reserved(min_channel);
 static ReservedChannelConstraint max_not_reserved(max_channel);
 
-static bool have_warned_ca_insecure = false;
-
 ConfigGroup ca_client_config("client", clientagent_config);
 ConfigVariable<string> ca_client_type("type", "libastron", ca_client_config);
 bool have_client_type(const string& backend)
@@ -105,14 +103,6 @@ ClientAgent::ClientAgent(RoleConfig roleconfig) : Role(roleconfig), m_net_accept
                                                  std::placeholders::_2,
                                                  std::placeholders::_3);
         m_net_acceptor = new TcpAcceptor(io_service, callback);
-
-        if(!have_warned_ca_insecure) {
-            have_warned_ca_insecure = true;
-            m_log->warning() << "\n==============================================\n"
-                             << "      CA not configured to use SSL!!!!!!\n"
-                             << " --- Do not use this config in production ---\n"
-                             << "==============================================\n";
-        }
     }
 
     // Handle SSL requested, but some information missing

--- a/src/clientagent/ClientAgent.h
+++ b/src/clientagent/ClientAgent.h
@@ -35,10 +35,14 @@ class ClientAgent : public Role
     ~ClientAgent();
 
     // handle_tcp generates a new Client object from a raw tcp connection.
-    void handle_tcp(boost::asio::ip::tcp::socket *socket);
+    void handle_tcp(boost::asio::ip::tcp::socket *socket,
+                    const boost::asio::ip::tcp::endpoint &remote,
+                    const boost::asio::ip::tcp::endpoint &local);
 
     // handle_ssl generates a new Client object from an ssl stream.
-    void handle_ssl(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+    void handle_ssl(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream,
+                    const boost::asio::ip::tcp::endpoint &remote,
+                    const boost::asio::ip::tcp::endpoint &local);
 
     // handle_datagram handles Datagrams received from the message director.
     // Currently the ClientAgent does not handle any datagrams,

--- a/src/clientagent/ClientFactory.cpp
+++ b/src/clientagent/ClientFactory.cpp
@@ -29,18 +29,20 @@ bool ClientFactory::has_client_type(const std::string &name)
 
 // instantiate_client creates a new Client object of type 'client_type'.
 Client* ClientFactory::instantiate_client(const std::string &client_type, ConfigNode config,
-        ClientAgent* client_agent, tcp::socket *socket)
+        ClientAgent* client_agent, tcp::socket *socket,
+        const tcp::endpoint &remote, const tcp::endpoint &local)
 {
     if(m_factories.find(client_type) != m_factories.end()) {
-        return m_factories[client_type]->instantiate(config, client_agent, socket);
+        return m_factories[client_type]->instantiate(config, client_agent, socket, remote, local);
     }
     return NULL;
 }
 Client* ClientFactory::instantiate_client(const std::string &client_type, ConfigNode config,
-        ClientAgent* client_agent, ssl::stream<tcp::socket> *stream)
+        ClientAgent* client_agent, ssl::stream<tcp::socket> *stream,
+        const tcp::endpoint &remote, const tcp::endpoint &local)
 {
     if(m_factories.find(client_type) != m_factories.end()) {
-        return m_factories[client_type]->instantiate(config, client_agent, stream);
+        return m_factories[client_type]->instantiate(config, client_agent, stream, remote, local);
     }
     return NULL;
 }

--- a/src/clientagent/ClientFactory.h
+++ b/src/clientagent/ClientFactory.h
@@ -9,9 +9,13 @@ class BaseClientType
 {
   public:
     virtual Client* instantiate(ConfigNode config, ClientAgent* client_agent,
-                                boost::asio::ip::tcp::socket *socket) = 0;
+                                boost::asio::ip::tcp::socket *socket,
+                                const boost::asio::ip::tcp::endpoint &remote,
+                                const boost::asio::ip::tcp::endpoint &local) = 0;
     virtual Client* instantiate(ConfigNode config, ClientAgent* client_agent,
-                                boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream) = 0;
+                                boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream,
+                                const boost::asio::ip::tcp::endpoint &remote,
+                                const boost::asio::ip::tcp::endpoint &local) = 0;
   protected:
     BaseClientType(const std::string &name);
 };
@@ -27,15 +31,19 @@ class ClientType : public BaseClientType
     }
 
     virtual Client* instantiate(ConfigNode config, ClientAgent* client_agent,
-                                boost::asio::ip::tcp::socket *socket)
+                                boost::asio::ip::tcp::socket *socket,
+                                const boost::asio::ip::tcp::endpoint &remote,
+                                const boost::asio::ip::tcp::endpoint &local)
     {
-        return new T(config, client_agent, socket);
+        return new T(config, client_agent, socket, remote, local);
     }
 
     virtual Client* instantiate(ConfigNode config, ClientAgent* client_agent,
-                                boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream)
+                                boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream,
+                                const boost::asio::ip::tcp::endpoint &remote,
+                                const boost::asio::ip::tcp::endpoint &local)
     {
-        return new T(config, client_agent, stream);
+        return new T(config, client_agent, stream, remote, local);
     }
 };
 
@@ -47,10 +55,14 @@ class ClientFactory
 
     // instantiate_client creates a new Client object of type 'client_type'.
     Client* instantiate_client(const std::string &client_type, ConfigNode config,
-                               ClientAgent* client_agent, boost::asio::ip::tcp::socket *socket);
+                               ClientAgent* client_agent, boost::asio::ip::tcp::socket *socket,
+                               const boost::asio::ip::tcp::endpoint &remote,
+                               const boost::asio::ip::tcp::endpoint &local);
     Client* instantiate_client(const std::string &client_type, ConfigNode config,
                                ClientAgent* client_agent,
-                               boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+                               boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream,
+                               const boost::asio::ip::tcp::endpoint &remote,
+                               const boost::asio::ip::tcp::endpoint &local);
     // add_client_type adds a factory for client of type 'name'
     // It is called automatically when instantiating a new ClientType.
     void add_client_type(const std::string &name, BaseClientType *factory);

--- a/src/messagedirector/MDNetworkParticipant.cpp
+++ b/src/messagedirector/MDNetworkParticipant.cpp
@@ -8,7 +8,7 @@ MDNetworkParticipant::MDNetworkParticipant(boost::asio::ip::tcp::socket *socket)
 {
     set_con_name("Network Participant");
 
-    m_client->set_socket(socket);
+    m_client->initialize(socket);
 }
 
 MDNetworkParticipant::~MDNetworkParticipant()

--- a/src/messagedirector/MDNetworkUpstream.cpp
+++ b/src/messagedirector/MDNetworkUpstream.cpp
@@ -19,7 +19,7 @@ boost::system::error_code MDNetworkUpstream::connect(const std::string &address)
     tcp::socket *socket = connector.connect(address, 7199, ec);
 
     if(socket) {
-        m_client->set_socket(socket);
+        m_client->initialize(socket);
     }
 
     return ec;

--- a/src/net/HAProxyHandler.cpp
+++ b/src/net/HAProxyHandler.cpp
@@ -70,7 +70,7 @@ void HAProxyHandler::handle_header(const boost::system::error_code &ec, size_t b
         // single byte past the end of the "\r\n" because that's going to be
         // application-layer data and we have no facility for putting it back
         // into the read buffer after we take it out.
-        
+
         // This function deals with it.
         handle_v1(ec, bytes_transferred);
     } else {
@@ -296,4 +296,5 @@ void HAProxyHandler::parse_v1()
 void HAProxyHandler::finish(const boost::system::error_code &ec)
 {
     m_callback(ec, m_remote, m_local);
+    delete this;
 }

--- a/src/net/HAProxyHandler.cpp
+++ b/src/net/HAProxyHandler.cpp
@@ -1,0 +1,299 @@
+#include "HAProxyHandler.h"
+#include <boost/bind.hpp>
+#include <cstring>
+
+using namespace boost::asio::ip;
+
+static const uint8_t haproxy_signature_v1[] = {
+    'P', 'R', 'O', 'X', 'Y', ' ', 'T', 'C', 'P'
+};
+static const uint8_t haproxy_signature_v2[] = {
+    0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A
+};
+
+void HAProxyHandler::async_process(tcp::socket *socket, ProxyCallback &callback)
+{
+    HAProxyHandler *handler = new HAProxyHandler(socket, callback);
+    handler->begin();
+}
+
+HAProxyHandler::HAProxyHandler(tcp::socket *socket, ProxyCallback &callback) :
+    m_socket(socket), m_callback(callback)
+{
+    boost::system::error_code ec;
+    m_remote = m_socket->remote_endpoint(ec);
+    m_local = m_socket->local_endpoint(ec);
+}
+
+HAProxyHandler::~HAProxyHandler()
+{
+    if(m_body_buf != nullptr) {
+        delete [] m_body_buf;
+    }
+}
+
+void HAProxyHandler::begin()
+{
+    async_read(*m_socket, boost::asio::buffer(m_header_buf, HAPROXY_HEADER_MIN),
+               boost::bind(&HAProxyHandler::handle_header, this,
+                           boost::asio::placeholders::error,
+                           boost::asio::placeholders::bytes_transferred));
+}
+
+void HAProxyHandler::handle_header(const boost::system::error_code &ec, size_t bytes_transferred)
+{
+    if(ec) {
+        // Something happened, abort!
+        finish(ec);
+        return;
+    }
+
+    if(bytes_transferred != HAPROXY_HEADER_MIN) {
+        boost::system::error_code epipe(boost::system::errc::errc_t::broken_pipe,
+                                        boost::system::system_category());
+        finish(epipe);
+        return;
+    }
+
+    if(!memcmp(m_header_buf, haproxy_signature_v2, sizeof(haproxy_signature_v2))) {
+        // Yay, it's a binary proxy header! These are easy to process:
+        m_body_len = (m_header_buf[14] << 8) | m_header_buf[15];
+        m_body_buf = new uint8_t[m_body_len];
+        async_read(*m_socket, boost::asio::buffer(m_body_buf, m_body_len),
+                   boost::bind(&HAProxyHandler::handle_v2, this,
+                               boost::asio::placeholders::error,
+                               boost::asio::placeholders::bytes_transferred));
+    } else if(!memcmp(m_header_buf, haproxy_signature_v1, sizeof(haproxy_signature_v1))) {
+        // This is the ASCII version (begins with "PROXY ", terminated by
+        // "\r\n"). These are harder to process, since we don't know how much
+        // proxy data there is in advance, and we can't risk reading even a
+        // single byte past the end of the "\r\n" because that's going to be
+        // application-layer data and we have no facility for putting it back
+        // into the read buffer after we take it out.
+        
+        // This function deals with it.
+        handle_v1(ec, bytes_transferred);
+    } else {
+        // Couldn't recognize any proxy header.
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+    }
+}
+
+void HAProxyHandler::handle_v2(const boost::system::error_code &ec, size_t bytes_transferred)
+{
+    if(ec) {
+        // Something happened, abort!
+        finish(ec);
+        return;
+    }
+
+    if(bytes_transferred != m_body_len) {
+        boost::system::error_code epipe(boost::system::errc::errc_t::broken_pipe,
+                                        boost::system::system_category());
+        finish(epipe);
+        return;
+    }
+
+    parse_v2();
+}
+
+void HAProxyHandler::parse_v2()
+{
+    boost::system::error_code no_error;
+
+    int version = (m_header_buf[12]>>4)&0xF;
+    int command = (m_header_buf[12])&0xF;
+    int family  = (m_header_buf[13]>>4)&0xF;
+    int transp  = (m_header_buf[13])&0xF;
+
+    if(version != 2) {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    if(family != 0x1 && family != 0x2) {
+        boost::system::error_code eafnosupport(boost::system::errc::errc_t::address_family_not_supported,
+                                               boost::system::system_category());
+        finish(eafnosupport);
+        return;
+    }
+
+    if(transp != 0x1) {
+        boost::system::error_code eprotonosupport(boost::system::errc::errc_t::protocol_not_supported,
+                                                  boost::system::system_category());
+        finish(eprotonosupport);
+        return;
+    }
+
+    if(command == 0x0) {
+        // LOCAL, ignore the body:
+        finish(no_error);
+        return;
+    }
+
+    if(command != 0x1) {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    if((family == 0x1 && m_body_len < 12) ||
+       (family == 0x2 && m_body_len < 36)) {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    address remote_address;
+    address local_address;
+    int port_offset;
+
+    if(family == 0x1) {
+        address_v4::bytes_type address_bytes;
+
+        memcpy(address_bytes.data(), &m_body_buf[0], 4);
+        address_v4 remote_v4(address_bytes);
+
+        memcpy(address_bytes.data(), &m_body_buf[4], 4);
+        address_v4 local_v4(address_bytes);
+
+        remote_address = remote_v4;
+        local_address = local_v4;
+
+        port_offset = 8;
+    } else {
+        address_v6::bytes_type address_bytes;
+
+        memcpy(address_bytes.data(), &m_body_buf[0], 16);
+        address_v6 remote_v6(address_bytes);
+
+        memcpy(address_bytes.data(), &m_body_buf[16], 16);
+        address_v6 local_v6(address_bytes);
+
+        remote_address = remote_v6;
+        local_address = local_v6;
+
+        port_offset = 32;
+    }
+
+    int remote_port = m_body_buf[port_offset]<<8 | m_body_buf[port_offset+1];
+    int local_port = m_body_buf[port_offset+2]<<8 | m_body_buf[port_offset+3];
+
+    m_remote = tcp::endpoint(remote_address, remote_port);
+    m_local = tcp::endpoint(local_address, local_port);
+    finish(no_error);
+}
+
+void HAProxyHandler::handle_v1(const boost::system::error_code &ec, size_t bytes_transferred)
+{
+    if(ec) {
+        // Something happened, abort!
+        finish(ec);
+        return;
+    }
+
+    if(bytes_transferred == 0) {
+        boost::system::error_code epipe(boost::system::errc::errc_t::broken_pipe,
+                                        boost::system::system_category());
+        finish(epipe);
+        return;
+    }
+
+    m_header_len += bytes_transferred;
+
+    // See if we got a '\n', indicating the end of the proxy header:
+    if(memrchr(m_header_buf, '\n', m_header_len) != nullptr) {
+        parse_v1();
+        return;
+    }
+
+    if(m_header_len >= HAPROXY_HEADER_MAX) {
+        boost::system::error_code eoverflow(boost::system::errc::errc_t::value_too_large,
+                                            boost::system::system_category());
+        finish(eoverflow);
+        return;
+    }
+    size_t remaining_size = HAPROXY_HEADER_MAX - m_header_len;
+
+    // Decide how many more bytes we want:
+    size_t read_size;
+    if(memrchr(m_header_buf, '\r', m_header_len) != nullptr) {
+        // There's a '\r', so '\n' is imminent!
+        read_size = 1;
+    } else {
+        // We can safely read at least 2 bytes. We also know that the finished
+        // PROXY header will have 5 spaces, with at least one char before each
+        // of the spaces. So we can read 2 + (5-number_of_spaces)*2 or
+        // 12 - number_of_spaces*2
+        read_size = 12;
+        for(uint8_t *i = m_header_buf; i < &m_header_buf[m_header_len]; i++)
+            if(*i == ' ')
+                read_size -= 2;
+    }
+
+    async_read(*m_socket,
+               boost::asio::buffer(&m_header_buf[m_header_len],
+                                   std::min(read_size, remaining_size)),
+               boost::bind(&HAProxyHandler::handle_v1, this,
+                           boost::asio::placeholders::error,
+                           boost::asio::placeholders::bytes_transferred));
+}
+
+void HAProxyHandler::parse_v1()
+{
+    if((m_header_buf[m_header_len-2] != '\r') ||
+       (m_header_buf[m_header_len-1] != '\n')) {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    m_header_buf[m_header_len] = '\0';
+
+    /* const char *proxy = */ strtok((char*)m_header_buf, " ");
+    const char *tcp = strtok(NULL, " ");
+    const char *srcip = strtok(NULL, " ");
+    const char *dstip = strtok(NULL, " ");
+    const char *srcport = strtok(NULL, " ");
+    const char *dstport = strtok(NULL, "\r");
+
+    if(dstport == nullptr) {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    address remote_address;
+    address local_address;
+
+    if(!strcmp(tcp, "TCP4")) {
+        remote_address = address_v4::from_string(srcip);
+        local_address = address_v4::from_string(dstip);
+    } else if(!strcmp(tcp, "TCP6")) {
+        remote_address = address_v6::from_string(srcip);
+        local_address = address_v6::from_string(dstip);
+    } else {
+        boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
+                                         boost::system::system_category());
+        finish(eproto);
+        return;
+    }
+
+    boost::system::error_code no_error;
+    m_remote = tcp::endpoint(remote_address, atoi(srcport));
+    m_local = tcp::endpoint(local_address, atoi(dstport));
+    finish(no_error);
+}
+
+void HAProxyHandler::finish(const boost::system::error_code &ec)
+{
+    m_callback(ec, m_remote, m_local);
+}

--- a/src/net/HAProxyHandler.cpp
+++ b/src/net/HAProxyHandler.cpp
@@ -103,10 +103,10 @@ void HAProxyHandler::parse_v2()
 {
     boost::system::error_code no_error;
 
-    int version = (m_header_buf[12]>>4)&0xF;
-    int command = (m_header_buf[12])&0xF;
-    int family  = (m_header_buf[13]>>4)&0xF;
-    int transp  = (m_header_buf[13])&0xF;
+    int version = (m_header_buf[12] >> 4) & 0xF;
+    int command = (m_header_buf[12]) & 0xF;
+    int family  = (m_header_buf[13] >> 4) & 0xF;
+    int transp  = (m_header_buf[13]) & 0xF;
 
     if(version != 2) {
         boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
@@ -124,7 +124,7 @@ void HAProxyHandler::parse_v2()
 
     if(transp != 0x1) {
         boost::system::error_code eprotonosupport(boost::system::errc::errc_t::protocol_not_supported,
-                                                  boost::system::system_category());
+                boost::system::system_category());
         finish(eprotonosupport);
         return;
     }
@@ -182,8 +182,8 @@ void HAProxyHandler::parse_v2()
         port_offset = 32;
     }
 
-    int remote_port = m_body_buf[port_offset]<<8 | m_body_buf[port_offset+1];
-    int local_port = m_body_buf[port_offset+2]<<8 | m_body_buf[port_offset+3];
+    int remote_port = m_body_buf[port_offset] << 8 | m_body_buf[port_offset + 1];
+    int local_port = m_body_buf[port_offset + 2] << 8 | m_body_buf[port_offset + 3];
 
     m_remote = tcp::endpoint(remote_address, remote_port);
     m_local = tcp::endpoint(local_address, local_port);
@@ -247,8 +247,8 @@ void HAProxyHandler::handle_v1(const boost::system::error_code &ec, size_t bytes
 
 void HAProxyHandler::parse_v1()
 {
-    if((m_header_buf[m_header_len-2] != '\r') ||
-       (m_header_buf[m_header_len-1] != '\n')) {
+    if((m_header_buf[m_header_len - 2] != '\r') ||
+       (m_header_buf[m_header_len - 1] != '\n')) {
         boost::system::error_code eproto(boost::system::errc::errc_t::protocol_error,
                                          boost::system::system_category());
         finish(eproto);

--- a/src/net/HAProxyHandler.h
+++ b/src/net/HAProxyHandler.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <boost/asio.hpp>
+#include <functional>
+
+// The HAProxyHandler class provides a single function, async_process, which
+// reads HAProxy PROXY protocol v1/v2 connection information. This takes great
+// care not to read any extra bytes after the proxy information, so that all
+// application-layer bytes stay in the read buffer, just as if the socket was a
+// direct connection. This allows the socket itself to be passed on to the
+// next stage in the upper-level connection handling logic (e.g. SSL handshake
+// or application-level network handlers.)
+
+// Maximum size of the HAProxy header, per documentation:
+#define HAPROXY_HEADER_MAX 107
+// Minimum size of the HAProxy header:
+#define HAPROXY_HEADER_MIN 16
+
+using boost::asio::ip::tcp;
+
+typedef std::function<void(const boost::system::error_code &, const tcp::endpoint &, const tcp::endpoint &)> ProxyCallback;
+
+class HAProxyHandler
+{
+  public:
+    static void async_process(tcp::socket *socket, ProxyCallback &callback);
+
+  private:
+    HAProxyHandler(tcp::socket *socket, ProxyCallback &callback);
+    ~HAProxyHandler();
+
+    void begin();
+
+    void handle_header(const boost::system::error_code &ec, size_t bytes_transferred);
+
+    void handle_v2(const boost::system::error_code &ec, size_t bytes_transferred);
+    void parse_v2();
+
+    void handle_v1(const boost::system::error_code &ec, size_t bytes_transferred);
+    void parse_v1();
+
+    void finish(const boost::system::error_code &ec);
+
+    tcp::socket *m_socket;
+    ProxyCallback m_callback;
+
+    tcp::endpoint m_remote;
+    tcp::endpoint m_local;
+
+    uint8_t m_header_buf[HAPROXY_HEADER_MAX+1];
+    size_t m_header_len = 0;
+
+    uint8_t *m_body_buf = nullptr;
+    size_t m_body_len = 0;
+};

--- a/src/net/HAProxyHandler.h
+++ b/src/net/HAProxyHandler.h
@@ -17,7 +17,8 @@
 
 using boost::asio::ip::tcp;
 
-typedef std::function<void(const boost::system::error_code &, const tcp::endpoint &, const tcp::endpoint &)> ProxyCallback;
+typedef std::function<void(const boost::system::error_code &, const tcp::endpoint &, const tcp::endpoint &)>
+ProxyCallback;
 
 class HAProxyHandler
 {
@@ -46,7 +47,7 @@ class HAProxyHandler
     tcp::endpoint m_remote;
     tcp::endpoint m_local;
 
-    uint8_t m_header_buf[HAPROXY_HEADER_MAX+1];
+    uint8_t m_header_buf[HAPROXY_HEADER_MAX + 1];
     size_t m_header_len = 0;
 
     uint8_t *m_body_buf = nullptr;

--- a/src/net/NetworkAcceptor.h
+++ b/src/net/NetworkAcceptor.h
@@ -14,7 +14,10 @@ class NetworkAcceptor
     void start();
     void stop();
 
-    inline void set_haproxy_mode(bool haproxy_mode) { m_haproxy_mode = haproxy_mode; }
+    inline void set_haproxy_mode(bool haproxy_mode)
+    {
+        m_haproxy_mode = haproxy_mode;
+    }
 
   protected:
     boost::asio::io_service &m_io_service;

--- a/src/net/NetworkAcceptor.h
+++ b/src/net/NetworkAcceptor.h
@@ -14,10 +14,13 @@ class NetworkAcceptor
     void start();
     void stop();
 
+    inline void set_haproxy_mode(bool haproxy_mode) { m_haproxy_mode = haproxy_mode; }
+
   protected:
     boost::asio::io_service &m_io_service;
     tcp::acceptor m_acceptor;
     bool m_started;
+    bool m_haproxy_mode = false;
 
     NetworkAcceptor(boost::asio::io_service&);
 

--- a/src/net/NetworkClient.cpp
+++ b/src/net/NetworkClient.cpp
@@ -25,7 +25,7 @@ NetworkClient::~NetworkClient()
     delete [] m_data_buf;
 }
 
-void NetworkClient::set_socket(tcp::socket *socket)
+void NetworkClient::initialize(tcp::socket *socket)
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
     if(m_socket) {
@@ -42,7 +42,7 @@ void NetworkClient::set_socket(tcp::socket *socket)
     start_receive();
 }
 
-void NetworkClient::set_socket(ssl::stream<tcp::socket> *stream)
+void NetworkClient::initialize(ssl::stream<tcp::socket> *stream)
 {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
     if(m_socket) {
@@ -52,7 +52,7 @@ void NetworkClient::set_socket(ssl::stream<tcp::socket> *stream)
     m_ssl_enabled = true;
     m_secure_socket = stream;
 
-    set_socket(&stream->next_layer());
+    initialize(&stream->next_layer());
 }
 
 void NetworkClient::start_receive()

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -40,7 +40,13 @@ class NetworkClient : public std::enable_shared_from_this<NetworkClient>
     ~NetworkClient();
 
     void initialize(boost::asio::ip::tcp::socket *socket);
+    void initialize(boost::asio::ip::tcp::socket *socket,
+                    const boost::asio::ip::tcp::endpoint &remote,
+                    const boost::asio::ip::tcp::endpoint &local);
     void initialize(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+    void initialize(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream,
+                    const boost::asio::ip::tcp::endpoint &remote,
+                    const boost::asio::ip::tcp::endpoint &local);
 
     // send_datagram immediately sends the datagram over TCP (blocking).
     void send_datagram(DatagramHandle dg);

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -56,11 +56,12 @@ class NetworkClient : public std::enable_shared_from_this<NetworkClient>
   private:
     /* Asynchronous call loop */
 
-    // start_receive is called by initialize()
-    //     after m_socket is set to a provided socket.
-    void start_receive();
+    // determine_endpoints is called by initialize() after m_socket is set to a
+    //     provided socket.
+    bool determine_endpoints(boost::asio::ip::tcp::endpoint &remote,
+                             boost::asio::ip::tcp::endpoint &local);
 
-    // async_receive is called by start_receive to begin receiving data, then by receive_size
+    // async_receive is called by initialize() to begin receiving data, then by receive_size
     //     or receive_data to wait for the next set of data.
     void async_receive();
 

--- a/src/net/NetworkClient.h
+++ b/src/net/NetworkClient.h
@@ -10,7 +10,7 @@
 // Do not subclass NetworkClient. Instead, you should implement NetworkHandler
 // and instantiate NetworkClient with std::make_shared.
 //
-// To begin receiving, pass it an ASIO socket or SSL stream via set_socket.
+// To begin receiving, pass it an ASIO socket or SSL stream via initialize().
 //
 // You must not destruct your NetworkHandler implementor until
 // receive_disconnect is called!
@@ -39,8 +39,8 @@ class NetworkClient : public std::enable_shared_from_this<NetworkClient>
     NetworkClient(NetworkHandler *handler);
     ~NetworkClient();
 
-    void set_socket(boost::asio::ip::tcp::socket *socket);
-    void set_socket(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
+    void initialize(boost::asio::ip::tcp::socket *socket);
+    void initialize(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *stream);
 
     // send_datagram immediately sends the datagram over TCP (blocking).
     void send_datagram(DatagramHandle dg);
@@ -56,7 +56,7 @@ class NetworkClient : public std::enable_shared_from_this<NetworkClient>
   private:
     /* Asynchronous call loop */
 
-    // start_receive is called by the constructor or set_socket
+    // start_receive is called by initialize()
     //     after m_socket is set to a provided socket.
     void start_receive();
 

--- a/src/net/SslAcceptor.cpp
+++ b/src/net/SslAcceptor.cpp
@@ -63,14 +63,18 @@ void SslAcceptor::handle_handshake(ssl::stream<tcp::socket> *socket,
         return;
     }
 
-    if(ec.value() != 0) {
+    boost::system::error_code endpoint_ec;
+    tcp::endpoint remote = socket->next_layer().remote_endpoint(endpoint_ec);
+    tcp::endpoint local = socket->next_layer().local_endpoint(endpoint_ec);
+
+    if(ec || endpoint_ec) {
         // The handshake failed for some reason. Free the socket and try again:
         delete socket;
         return;
     }
 
     // Inform the callback:
-    m_callback(socket);
+    m_callback(socket, remote, local);
 }
 
 void SslAcceptor::handle_timeout(ssl::stream<tcp::socket> *socket)

--- a/src/net/SslAcceptor.h
+++ b/src/net/SslAcceptor.h
@@ -5,7 +5,7 @@
 #include <boost/asio/ssl.hpp>
 namespace ssl = boost::asio::ssl;
 
-typedef std::function<void(ssl::stream<tcp::socket>*)> SslAcceptorCallback;
+typedef std::function<void(ssl::stream<tcp::socket>*, tcp::endpoint, tcp::endpoint)> SslAcceptorCallback;
 
 class SslAcceptor : public NetworkAcceptor
 {

--- a/src/net/SslAcceptor.h
+++ b/src/net/SslAcceptor.h
@@ -22,6 +22,13 @@ class SslAcceptor : public NetworkAcceptor
 
     virtual void start_accept();
     void handle_accept(ssl::stream<tcp::socket> *socket, const boost::system::error_code &ec);
-    void handle_handshake(ssl::stream<tcp::socket> *socket, std::shared_ptr<Timeout> timeout, const boost::system::error_code &ec);
+    void handle_endpoints(ssl::stream<tcp::socket> *socket,
+                          const boost::system::error_code &ec,
+                          const boost::asio::ip::tcp::endpoint &remote,
+                          const boost::asio::ip::tcp::endpoint &local);
+    void handle_handshake(ssl::stream<tcp::socket> *socket, std::shared_ptr<Timeout> timeout,
+                          const boost::system::error_code &ec,
+                          const boost::asio::ip::tcp::endpoint &remote,
+                          const boost::asio::ip::tcp::endpoint &local);
     void handle_timeout(ssl::stream<tcp::socket> *socket);
 };

--- a/src/net/SslAcceptor.h
+++ b/src/net/SslAcceptor.h
@@ -5,7 +5,8 @@
 #include <boost/asio/ssl.hpp>
 namespace ssl = boost::asio::ssl;
 
-typedef std::function<void(ssl::stream<tcp::socket>*, tcp::endpoint, tcp::endpoint)> SslAcceptorCallback;
+typedef std::function<void(ssl::stream<tcp::socket>*, tcp::endpoint, tcp::endpoint)>
+SslAcceptorCallback;
 
 class SslAcceptor : public NetworkAcceptor
 {
@@ -14,7 +15,10 @@ class SslAcceptor : public NetworkAcceptor
                 SslAcceptorCallback &callback);
     virtual ~SslAcceptor() {}
 
-    inline void set_handshake_timeout(int milliseconds) { m_handshake_timeout = milliseconds; }
+    inline void set_handshake_timeout(int milliseconds)
+    {
+        m_handshake_timeout = milliseconds;
+    }
 
   private:
     ssl::context& m_context;

--- a/src/net/TcpAcceptor.cpp
+++ b/src/net/TcpAcceptor.cpp
@@ -24,7 +24,11 @@ void TcpAcceptor::handle_accept(tcp::socket *socket, const boost::system::error_
         return;
     }
 
-    if(ec.value() != 0) {
+    boost::system::error_code endpoint_ec;
+    tcp::endpoint remote = socket->remote_endpoint(endpoint_ec);
+    tcp::endpoint local = socket->local_endpoint(endpoint_ec);
+
+    if(ec || endpoint_ec) {
         // The accept failed for some reason. Free the socket and try again:
         delete socket;
         start_accept();
@@ -32,7 +36,7 @@ void TcpAcceptor::handle_accept(tcp::socket *socket, const boost::system::error_
     }
 
     // Inform the callback:
-    m_callback(socket);
+    m_callback(socket, remote, local);
 
     // Start accepting again:
     start_accept();

--- a/src/net/TcpAcceptor.cpp
+++ b/src/net/TcpAcceptor.cpp
@@ -1,4 +1,5 @@
 #include "TcpAcceptor.h"
+#include "HAProxyHandler.h"
 #include <boost/bind.hpp>
 
 TcpAcceptor::TcpAcceptor(boost::asio::io_service &io_service,
@@ -24,20 +25,40 @@ void TcpAcceptor::handle_accept(tcp::socket *socket, const boost::system::error_
         return;
     }
 
-    boost::system::error_code endpoint_ec;
-    tcp::endpoint remote = socket->remote_endpoint(endpoint_ec);
-    tcp::endpoint local = socket->local_endpoint(endpoint_ec);
+    // Start accepting another connection now:
+    start_accept();
 
-    if(ec || endpoint_ec) {
-        // The accept failed for some reason. Free the socket and try again:
+    if(ec) {
+        // The accept failed for some reason.
         delete socket;
-        start_accept();
+        return;
+    }
+
+    if(m_haproxy_mode) {
+        ProxyCallback callback = std::bind(&TcpAcceptor::handle_endpoints,
+                                           this, socket,
+                                           std::placeholders::_1,
+                                           std::placeholders::_2,
+                                           std::placeholders::_3);
+        HAProxyHandler::async_process(socket, callback);
+    } else {
+        boost::system::error_code endpoint_ec;
+        tcp::endpoint remote = socket->remote_endpoint(endpoint_ec);
+        tcp::endpoint local = socket->local_endpoint(endpoint_ec);
+        handle_endpoints(socket, endpoint_ec, remote, local);
+    }
+}
+
+void TcpAcceptor::handle_endpoints(tcp::socket *socket, const boost::system::error_code &ec,
+                                   const tcp::endpoint &remote,
+                                   const tcp::endpoint &local)
+{
+    if(ec) {
+        // The accept failed for some reason.
+        delete socket;
         return;
     }
 
     // Inform the callback:
     m_callback(socket, remote, local);
-
-    // Start accepting again:
-    start_accept();
 }

--- a/src/net/TcpAcceptor.h
+++ b/src/net/TcpAcceptor.h
@@ -16,4 +16,6 @@ class TcpAcceptor : public NetworkAcceptor
 
     virtual void start_accept();
     void handle_accept(tcp::socket *socket, const boost::system::error_code &ec);
+    void handle_endpoints(tcp::socket *socket, const boost::system::error_code &ec,
+                          const tcp::endpoint &remote, const tcp::endpoint &local);
 };

--- a/src/net/TcpAcceptor.h
+++ b/src/net/TcpAcceptor.h
@@ -2,7 +2,7 @@
 #include "NetworkAcceptor.h"
 #include <functional>
 
-typedef std::function<void(tcp::socket*)> TcpAcceptorCallback;
+typedef std::function<void(tcp::socket*, tcp::endpoint, tcp::endpoint)> TcpAcceptorCallback;
 
 class TcpAcceptor : public NetworkAcceptor
 {

--- a/test/test_clientagent.py
+++ b/test/test_clientagent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-import unittest, time, ssl
+import unittest, time, ssl, struct
 from socket import socket, AF_INET, SOCK_STREAM
 from common.unittests import ProtocolTest
 from common.astron import *
@@ -66,6 +66,25 @@ roles:
           key_file: %r
 
     - type: clientagent
+      bind: 127.0.0.1:57223
+      version: "Sword Art Online v5.1"
+      haproxy: true
+      channels:
+          min: 440600
+          max: 440649
+
+    - type: clientagent
+      bind: 127.0.0.1:57224
+      version: "Sword Art Online v5.1"
+      haproxy: true
+      channels:
+          min: 440650
+          max: 440699
+      tls:
+          certificate: %r
+          key_file: %r
+
+    - type: clientagent
       bind: 127.0.0.1:51201
       version: "Sword Art Online v5.1"
       channels:
@@ -74,7 +93,7 @@ roles:
       client:
           heartbeat_timeout: 1000
 
-""" % (USE_THREADING, test_dc, server_crt, server_key)
+""" % (USE_THREADING, test_dc, server_crt, server_key, server_crt, server_key)
 VERSION = 'Sword Art Online v5.1'
 
 class TestClientAgent(ProtocolTest):
@@ -104,11 +123,14 @@ class TestClientAgent(ProtocolTest):
                 s.close()
                 return
 
-    def connect(self, do_hello=True, port=57128, tls_opts=None):
+    def connect(self, do_hello=True, port=57128, tls_opts=None, proxy_header=None):
         s = socket(AF_INET, SOCK_STREAM)
+        s.connect(('127.0.0.1', port))
+        if proxy_header is not None:
+            s.send(proxy_header)
         if tls_opts is not None:
             s = ssl.wrap_socket(s,**tls_opts)
-        s.connect(('127.0.0.1', port))
+
         client = ClientConnection(s)
 
         if do_hello:
@@ -3037,6 +3059,66 @@ class TestClientAgent(ProtocolTest):
         dgi.read_uint16() # Ignore local port (can't really test this)
 
         self.server.send(Datagram.create_remove_channel(10052))
+
+    def test_haproxy_protocol(self):
+        self.server.flush()
+        self.server.send(Datagram.create_add_channel(10010))
+
+        for test_id in xrange(8):
+            proto_v2 = bool(test_id&1)
+            ipv6 = bool(test_id&2)
+            tls = bool(test_id&4)
+
+            if ipv6:
+                source_ip = '2001:db8::1'
+                source_ip_bin = '20010db8000000000000000000000001'.decode('hex')
+                dest_ip = '2001:db8:dead:beef:0:face:feed:1'
+                dest_ip_bin = '20010db8deadbeef0000facefeed0001'.decode('hex')
+            else:
+                source_ip = '203.0.113.5'
+                source_ip_bin = struct.pack('BBBB', 203, 0, 113, 5)
+                dest_ip = '198.51.100.77'
+                dest_ip_bin = struct.pack('BBBB', 198, 51, 100, 77)
+
+            source_port = 54321
+            dest_port = 12345
+
+            if proto_v2:
+                body = (source_ip_bin + dest_ip_bin +
+                        struct.pack('>HH', source_port, dest_port))
+                header = ('\r\n\r\n\0\r\nQUIT\n\x21' +
+                          struct.pack('>BH', 0x21 if ipv6 else 0x11, len(body)) +
+                          body)
+            else:
+                header = 'PROXY TCP{} {} {} {} {}\r\n'.format(
+                    6 if ipv6 else 4, source_ip, dest_ip, source_port, dest_port)
+
+            if tls:
+                tls_context = {'ssl_version': ssl.PROTOCOL_TLSv1}
+                client = self.connect(port=57224, proxy_header=header, tls_opts=tls_context)
+            else:
+                client = self.connect(port=57223, proxy_header=header)
+
+            id = self.identify(client, min=440600, max=440699)
+            dg = Datagram.create([id], 10010, CLIENTAGENT_GET_NETWORK_ADDRESS)
+            dg.add_uint32(test_id)
+            self.server.send(dg)
+
+            dg = self.server.recv_maybe()
+            self.assertTrue(dg is not None, "The server didn't receive a datagram. Expecting CLIENTAGENT_GET_NETWORK_ADDRESS_RESP")
+
+            dgi = DatagramIterator(dg)
+            self.assertEqual(dgi.read_uint8(), 1)
+            self.assertEqual(dgi.read_channel(), 10010)
+            self.assertEqual(dgi.read_channel(), id)
+            self.assertEqual(dgi.read_uint16(), CLIENTAGENT_GET_NETWORK_ADDRESS_RESP)
+            self.assertEqual(dgi.read_uint32(), test_id)
+            self.assertEqual(dgi.read_string(), source_ip)
+            self.assertEqual(dgi.read_uint16(), source_port)
+            self.assertEqual(dgi.read_string(), dest_ip)
+            self.assertEqual(dgi.read_uint16(), dest_port)
+
+        self.server.send(Datagram.create_remove_channel(10010))
 
     # Test the interest timeout
     # The heartbeat timeout is configured for 1000ms (1 second)


### PR DESCRIPTION
This adds an extra flag to the ClientAgent role titled `haproxy` that, when set to `true`, configures the CA to expect a [PROXY protocol header](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) at the beginning of the connection.

This allows the connection endpoint information (a la `CLIENTAGENT_GET_NETWORK_ADDRESS`) to persist across a layer-4 proxy that speaks the PROXY protocol (v1/v2). The added benefit here is that the proxy can even do the SSL termination.

Some software which could be used to do this:
- AWS Elastic Load Balancers
- HAProxy
- Stunnel