### PR TITLE
general: Replace instances of NULL with nullptr

### DIFF
--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -84,7 +84,7 @@ void Client::log_event(LoggedEvent &event)
 }
 
 // lookup_object returns the class of the object with a do_id.
-// If that object is not visible to the client, NULL will be returned instead.
+// If that object is not visible to the client, nullptr will be returned instead.
 const Class *Client::lookup_object(doid_t do_id)
 {
     // First see if it's an UberDOG:
@@ -107,7 +107,7 @@ const Class *Client::lookup_object(doid_t do_id)
     }
 
     // We're at the end of our rope; we have no clue what this object is.
-    return NULL;
+    return nullptr;
 }
 
 // lookup_interests returns a list of all the interests that a parent-zone pair is visible to.

--- a/src/clientagent/Client.h
+++ b/src/clientagent/Client.h
@@ -136,7 +136,7 @@ class Client : public MDParticipantInterface
     void log_event(LoggedEvent &event);
 
     // lookup_object returns the class of the object with a do_id.
-    // If that object is not visible to the client, NULL will be returned instead.
+    // If that object is not visible to the client, nullptr will be returned instead.
     const dclass::Class* lookup_object(doid_t do_id);
 
     // lookup_interests returns a list of all the interests that a parent-zone pair is visible to.

--- a/src/clientagent/ClientFactory.cpp
+++ b/src/clientagent/ClientFactory.cpp
@@ -35,7 +35,7 @@ Client* ClientFactory::instantiate_client(const std::string &client_type, Config
     if(m_factories.find(client_type) != m_factories.end()) {
         return m_factories[client_type]->instantiate(config, client_agent, socket, remote, local);
     }
-    return NULL;
+    return nullptr;
 }
 Client* ClientFactory::instantiate_client(const std::string &client_type, ConfigNode config,
         ClientAgent* client_agent, ssl::stream<tcp::socket> *stream,
@@ -44,5 +44,5 @@ Client* ClientFactory::instantiate_client(const std::string &client_type, Config
     if(m_factories.find(client_type) != m_factories.end()) {
         return m_factories[client_type]->instantiate(config, client_agent, stream, remote, local);
     }
-    return NULL;
+    return nullptr;
 }

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -71,7 +71,7 @@ LockedLogOutput Logger::log(LogSeverity sev)
     const char *sevtext;
 
     if(sev < m_severity) {
-        LockedLogOutput null_out(NULL, NULL);
+        LockedLogOutput null_out(nullptr, nullptr);
         return null_out;
     }
 

--- a/src/core/RoleFactory.cpp
+++ b/src/core/RoleFactory.cpp
@@ -24,5 +24,5 @@ Role* RoleFactory::instantiate_role(const std::string &role_name, RoleConfig rol
     if(m_factories.find(role_name) != m_factories.end()) {
         return m_factories[role_name]->instantiate(roleconfig);
     }
-    return NULL;
+    return nullptr;
 }

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -3,7 +3,7 @@
 #include "config/ConfigGroup.h"
 
 /* Global Variables */
-const dclass::File *g_dcf = NULL;
+const dclass::File *g_dcf = nullptr;
 Logger *g_logger = new Logger;
 ConfigFile *g_config = new ConfigFile;
 boost::asio::io_service io_service;

--- a/src/core/shutdown.cpp
+++ b/src/core/shutdown.cpp
@@ -65,7 +65,7 @@ void astron_handle_signals()
     interruptHandler.sa_handler = handle_interrupt;
     sigemptyset(&interruptHandler.sa_mask);
     interruptHandler.sa_flags = 0;
-    sigaction(SIGINT, &interruptHandler, NULL);
+    sigaction(SIGINT, &interruptHandler, nullptr);
 }
 
 #endif

--- a/src/database/DBBackendFactory.cpp
+++ b/src/database/DBBackendFactory.cpp
@@ -18,7 +18,7 @@ DatabaseBackend* DBBackendFactory::instantiate_backend(const std::string &backen
     if(m_factories.find(backend_name) != m_factories.end()) {
         return m_factories[backend_name]->instantiate(config, min_id, max_id);
     }
-    return NULL;
+    return nullptr;
 }
 
 // add_backend adds a factory for backend of type 'name'

--- a/src/database/DBOperation.h
+++ b/src/database/DBOperation.h
@@ -54,13 +54,13 @@ class DBOperation
 
         // SET_FIELDS operations are for setting (replaces existiing) fields on an object.
         // This includes adding unset fields, deleting set fields, and changing existing fields.
-        // The changes are in the m_set_fields map, where NULL represents a field deletion.
+        // The changes are in the m_set_fields map, where nullptr represents a field deletion.
         SET_FIELDS,
 
         // UPDATE_FIELDS operations are like set fields operations, but with conditions
         // typically to verify that the object is in a sane state before applying updates.
         // The m_criteria_fields map can be used to specify the state of
-        // the "if empty" or "if equal" fields where NULL represents empty/absent.
+        // the "if empty" or "if equal" fields where nullptr represents empty/absent.
         UPDATE_FIELDS
     };
 

--- a/src/database/MongoDatabase.cpp
+++ b/src/database/MongoDatabase.cpp
@@ -731,7 +731,7 @@ class MongoDatabase : public DatabaseBackend
         operation->on_failure();
     }
 
-    // Get a DBObjectSnapshot from a MongoDB BSON object; returns NULL if failure.
+    // Get a DBObjectSnapshot from a MongoDB BSON object; returns nullptr if failure.
     DBObjectSnapshot *format_snapshot(doid_t doid, const BSONObj &obj)
     {
         m_log->trace() << "Formatting database snapshot of " << doid << ": "
@@ -742,7 +742,7 @@ class MongoDatabase : public DatabaseBackend
             if(!dclass) {
                 m_log->error() << "Encountered unknown database object: "
                                << dclass_name << "(" << doid << ")" << endl;
-                return NULL;
+                return nullptr;
             }
 
             BSONObj fields = obj["fields"].Obj();
@@ -771,7 +771,7 @@ class MongoDatabase : public DatabaseBackend
             m_log->error() << "Unexpected error while trying to format"
                            " database snapshot for " << doid << ": "
                            << e.what() << endl;
-            return NULL;
+            return nullptr;
         }
     }
 

--- a/src/database/SociSQLDatabase.cpp
+++ b/src/database/SociSQLDatabase.cpp
@@ -134,11 +134,11 @@ class SociSQLDatabase : public OldDatabaseBackend
         try {
             m_sql << "SELECT class_id FROM objects WHERE id=" << do_id << ";", into(dc_id, ind);
         } catch(const soci_error &e) {
-            return NULL;
+            return nullptr;
         }
 
         if(ind != i_ok || dc_id == -1) {
-            return NULL;
+            return nullptr;
         }
 
         return g_dcf->get_class_by_id(dc_id);

--- a/src/database/YAMLDatabase.cpp
+++ b/src/database/YAMLDatabase.cpp
@@ -254,7 +254,7 @@ class YAMLDatabase : public OldDatabaseBackend
         // Open file for object
         YAML::Node document;
         if(!load(do_id, document)) {
-            return NULL;
+            return nullptr;
         }
 
         return g_dcf->get_class_by_name(document["class"].as<string>());

--- a/src/dclass/dc/ArrayType.cpp
+++ b/src/dclass/dc/ArrayType.cpp
@@ -17,7 +17,7 @@ namespace dclass   // open namespace
 ArrayType::ArrayType(DistributedType* element_type, const NumericRange& size) :
     m_element_type(element_type), m_array_range(size)
 {
-    if(m_element_type == (DistributedType*)NULL) {
+    if(m_element_type == nullptr) {
         m_element_type = DistributedType::invalid;
     }
 
@@ -57,7 +57,7 @@ ArrayType::ArrayType(DistributedType* element_type, const NumericRange& size) :
     }
 }
 
-// as_array returns this as an ArrayType if it is an array, or NULL otherwise.
+// as_array returns this as an ArrayType if it is an array, or nullptr otherwise.
 ArrayType* ArrayType::as_array()
 {
     return this;

--- a/src/dclass/dc/ArrayType.h
+++ b/src/dclass/dc/ArrayType.h
@@ -17,7 +17,7 @@ class ArrayType : public DistributedType
   public:
     ArrayType(DistributedType* element_type, const NumericRange &size = NumericRange());
 
-    // as_array returns this as a ArrayType if it is an array/string/blob, or NULL otherwise.
+    // as_array returns this as a ArrayType if it is an array/string/blob, or nullptr otherwise.
     virtual ArrayType* as_array();
     virtual const ArrayType* as_array() const;
 

--- a/src/dclass/dc/Class.cpp
+++ b/src/dclass/dc/Class.cpp
@@ -10,19 +10,17 @@ namespace dclass   // open namespace
 
 
 // constructor
-Class::Class(File* file, const string &name) : Struct(file, name), m_constructor(NULL)
+Class::Class(File* file, const string &name) : Struct(file, name), m_constructor(nullptr)
 {
 }
 
 // destructor
 Class::~Class()
 {
-    if(m_constructor != (Field*)NULL) {
-        delete m_constructor;
-    }
+    delete m_constructor;
 }
 
-// as_class returns this Struct as a Class if it is a Class, or NULL otherwise.
+// as_class returns this Struct as a Class if it is a Class, or nullptr otherwise.
 Class* Class::as_class()
 {
     return this;
@@ -61,12 +59,12 @@ void Class::add_child(Class* child)
 bool Class::add_field(Field *field)
 {
     // Field can't be null
-    if(field == (Field*)NULL) {
+    if(field == nullptr) {
         return false;
     }
 
     // Classes can't share fields.
-    if(field->get_struct() != NULL && field->get_struct() != this) {
+    if(field->get_struct() != nullptr && field->get_struct() != this) {
         return false;
     }
 
@@ -78,7 +76,7 @@ bool Class::add_field(Field *field)
     // If the field has the same name as the class, it is a constructor
     if(field->get_name() == m_name) {
         // Make sure we don't already have a constructor
-        if(m_constructor != (Field*)NULL) {
+        if(m_constructor != nullptr) {
             return false;
         }
 
@@ -128,7 +126,7 @@ bool Class::add_field(Field *field)
     m_fields_by_name[field->get_name()] = field;
 
     // Update our size
-    if(field->as_molecular() == (MolecularField*)NULL
+    if(field->as_molecular() == nullptr
        && (has_fixed_size() || m_fields.size() == 1)) {
         if(field->get_type()->has_fixed_size()) {
             m_size += field->get_type()->get_size();
@@ -242,7 +240,7 @@ void Class::generate_hash(HashGenerator& hashgen) const
     }
 
     /* Hash our constructor */
-    if(m_constructor != (Field*)NULL) {
+    if(m_constructor != nullptr) {
         m_constructor->generate_hash(hashgen);
     }
 

--- a/src/dclass/dc/Class.h
+++ b/src/dclass/dc/Class.h
@@ -16,7 +16,7 @@ class Class : public Struct
     Class(File *dc_file, const std::string &name);
     virtual ~Class();
 
-    // as_class returns this Struct as a Class if it is a Class, or NULL otherwise.
+    // as_class returns this Struct as a Class if it is a Class, or nullptr otherwise.
     virtual Class* as_class();
     virtual const Class* as_class() const;
 
@@ -35,7 +35,7 @@ class Class : public Struct
     //     or false if it just uses the default constructor.
     inline bool has_constructor() const;
     // get_constructor returns the constructor method for this class if it is defined,
-    //     or NULL if the class uses the default constructor.
+    //     or nullptr if the class uses the default constructor.
     inline Field* get_constructor();
     inline const Field* get_constructor() const;
 

--- a/src/dclass/dc/Class.ipp
+++ b/src/dclass/dc/Class.ipp
@@ -37,10 +37,10 @@ inline const Class* Class::get_child(unsigned int n) const
 //     or false if it just uses the default constructor.
 inline bool Class::has_constructor() const
 {
-	return (m_constructor != (Field*)NULL);
+	return (m_constructor != nullptr);
 }
 // get_constructor returns the constructor method for this class if it is defined,
-//     or NULL if the class uses the default constructor.
+//     or nullptr if the class uses the default constructor.
 inline Field* Class::get_constructor()
 {
 	return m_constructor;

--- a/src/dclass/dc/DistributedType.cpp
+++ b/src/dclass/dc/DistributedType.cpp
@@ -11,44 +11,44 @@ DistributedType::~DistributedType()
 {
 }
 
-// as_number returns this as a NumericType if it is numeric, or NULL otherwise.
+// as_number returns this as a NumericType if it is numeric, or nullptr otherwise.
 NumericType* DistributedType::as_numeric()
 {
-    return (NumericType*)NULL;
+    return nullptr;
 }
 const NumericType* DistributedType::as_numeric() const
 {
-    return (const NumericType*)NULL;
+    return nullptr;
 }
 
-// as_array returns this as an ArrayType if it is an array, or NULL otherwise.
+// as_array returns this as an ArrayType if it is an array, or nullptr otherwise.
 ArrayType* DistributedType::as_array()
 {
-    return (ArrayType*)NULL;
+    return nullptr;
 }
 const ArrayType* DistributedType::as_array() const
 {
-    return (const ArrayType*)NULL;
+    return nullptr;
 }
 
-// as_struct returns this as a Struct if it is a struct, or NULL otherwise.
+// as_struct returns this as a Struct if it is a struct, or nullptr otherwise.
 Struct* DistributedType::as_struct()
 {
-    return (Struct*)NULL;
+    return nullptr;
 }
 const Struct* DistributedType::as_struct() const
 {
-    return (const Struct*)NULL;
+    return nullptr;
 }
 
-// as_method returns this as a Method if it is a method, or NULL otherwise.
+// as_method returns this as a Method if it is a method, or nullptr otherwise.
 Method* DistributedType::as_method()
 {
-    return (Method*)NULL;
+    return nullptr;
 }
 const Method* DistributedType::as_method() const
 {
-    return (const Method*)NULL;
+    return nullptr;
 }
 
 // generate_hash accumulates the properties of this field into the hash.

--- a/src/dclass/dc/DistributedType.h
+++ b/src/dclass/dc/DistributedType.h
@@ -70,19 +70,19 @@ class DistributedType
     // set_alias gives this type the alternate name <alias>.
     inline void set_alias(const std::string& alias);
 
-    // as_numeric returns this as a NumericType if it is numeric, or NULL otherwise.
+    // as_numeric returns this as a NumericType if it is numeric, or nullptr otherwise.
     virtual NumericType* as_numeric();
     virtual const NumericType* as_numeric() const;
 
-    // as_array returns this as an ArrayType if it is an array, or NULL otherwise.
+    // as_array returns this as an ArrayType if it is an array, or nullptr otherwise.
     virtual ArrayType* as_array();
     virtual const ArrayType* as_array() const;
 
-    // as_struct returns this as a Struct if it is a struct, or NULL otherwise.
+    // as_struct returns this as a Struct if it is a struct, or nullptr otherwise.
     virtual Struct* as_struct();
     virtual const Struct* as_struct() const;
 
-    // as_method returns this as a Method if it is a method, or NULL otherwise.
+    // as_method returns this as a Method if it is a method, or nullptr otherwise.
     virtual Method* as_method();
     virtual const Method* as_method() const;
 

--- a/src/dclass/dc/Field.cpp
+++ b/src/dclass/dc/Field.cpp
@@ -10,11 +10,11 @@ namespace dclass   // open namespace
 
 // constructor
 Field::Field(DistributedType* type, const std::string &name) :
-    m_struct(NULL), m_id(0), m_name(name), m_type(type), m_has_default_value(false)
+    m_struct(nullptr), m_id(0), m_name(name), m_type(type), m_has_default_value(false)
 {
     bool implicit_value;
 
-    if(m_type == NULL) {
+    if(m_type == nullptr) {
         m_type = DistributedType::invalid;
     } else {
         m_default_value = create_default_value(type, implicit_value);
@@ -28,14 +28,14 @@ Field::~Field()
     delete m_type;
 }
 
-// as_molecular returns this as a MolecularField if it is molecular, or NULL otherwise.
+// as_molecular returns this as a MolecularField if it is molecular, or nullptr otherwise.
 MolecularField* Field::as_molecular()
 {
-    return (MolecularField*)NULL;
+    return nullptr;
 }
 const MolecularField* Field::as_molecular() const
 {
-    return (MolecularField*)NULL;
+    return nullptr;
 }
 
 // set_name sets the name of this field.  Returns false if a field with
@@ -43,7 +43,7 @@ const MolecularField* Field::as_molecular() const
 bool Field::set_name(const std::string& name)
 {
     // Check to make sure no other fields in our struct have this name
-    if(m_struct != (Struct*)NULL && m_struct->get_field_by_name(name) != (Field*)NULL) {
+    if(m_struct != nullptr && m_struct->get_field_by_name(name) != nullptr) {
         return false;
     }
 

--- a/src/dclass/dc/Field.h
+++ b/src/dclass/dc/Field.h
@@ -19,7 +19,7 @@ class Field : public KeywordList
     Field(DistributedType* type, const std::string &name = "");
     virtual ~Field();
 
-    // as_molecular returns this as a MolecularField if it is molecular, or NULL otherwise.
+    // as_molecular returns this as a MolecularField if it is molecular, or nullptr otherwise.
     virtual MolecularField* as_molecular();
     virtual const MolecularField* as_molecular() const;
 

--- a/src/dclass/dc/File.cpp
+++ b/src/dclass/dc/File.cpp
@@ -38,49 +38,49 @@ File::~File()
     m_keywords.clear();
 }
 
-// get_class_by_id returns the requested class or NULL if there is no such class.
+// get_class_by_id returns the requested class or nullptr if there is no such class.
 Class* File::get_class_by_id(unsigned int id)
 {
     DistributedType* dt = get_type_by_id(id);
-    if(dt == NULL) {
-        return NULL;
+    if(dt == nullptr) {
+        return nullptr;
     }
-    if(dt->as_struct() == NULL) {
-        return NULL;
+    if(dt->as_struct() == nullptr) {
+        return nullptr;
     }
     return dt->as_struct()->as_class();
 }
 const Class* File::get_class_by_id(unsigned int id) const
 {
     const DistributedType* dt = get_type_by_id(id);
-    if(dt == NULL) {
-        return NULL;
+    if(dt == nullptr) {
+        return nullptr;
     }
-    if(dt->as_struct() == NULL) {
-        return NULL;
+    if(dt->as_struct() == nullptr) {
+        return nullptr;
     }
     return dt->as_struct()->as_class();
 }
-// get_class_by_name returns the requested class or NULL if there is no such class.
+// get_class_by_name returns the requested class or nullptr if there is no such class.
 Class* File::get_class_by_name(const std::string &name)
 {
     DistributedType* dt = get_type_by_name(name);
-    if(dt == NULL) {
-        return NULL;
+    if(dt == nullptr) {
+        return nullptr;
     }
-    if(dt->as_struct() == NULL) {
-        return NULL;
+    if(dt->as_struct() == nullptr) {
+        return nullptr;
     }
     return dt->as_struct()->as_class();
 }
 const Class* File::get_class_by_name(const std::string &name) const
 {
     const DistributedType* dt = get_type_by_name(name);
-    if(dt == NULL) {
-        return NULL;
+    if(dt == nullptr) {
+        return nullptr;
     }
-    if(dt->as_struct() == NULL) {
-        return NULL;
+    if(dt->as_struct() == nullptr) {
+        return nullptr;
     }
     return dt->as_struct()->as_class();
 }

--- a/src/dclass/dc/File.h
+++ b/src/dclass/dc/File.h
@@ -42,24 +42,24 @@ class File
     inline Struct* get_struct(unsigned int n);
     inline const Struct* get_struct(unsigned int n) const;
 
-    // get_class_by_id returns the requested class or NULL if there is no such class.
+    // get_class_by_id returns the requested class or nullptr if there is no such class.
     Class* get_class_by_id(unsigned int id);
     const Class* get_class_by_id(unsigned int id) const;
-    // get_class_by_name returns the requested class or NULL if there is no such class.
+    // get_class_by_name returns the requested class or nullptr if there is no such class.
     Class* get_class_by_name(const std::string &name);
     const Class* get_class_by_name(const std::string &name) const;
 
     // get_num_types returns the number of types in the file.
     //     All type ids will be within the range 0 <= id < get_num_types().
     inline size_t get_num_types() const;
-    // get_type_by_id returns the requested type or NULL if there is no such type.
+    // get_type_by_id returns the requested type or nullptr if there is no such type.
     inline DistributedType* get_type_by_id(unsigned int id);
     inline const DistributedType* get_type_by_id(unsigned int id) const;
-    // get_type_by_name returns the requested type or NULL if there is no such type.
+    // get_type_by_name returns the requested type or nullptr if there is no such type.
     inline DistributedType* get_type_by_name(const std::string &name);
     inline const DistributedType* get_type_by_name(const std::string &name) const;
 
-    // get_field_by_id returns the request field or NULL if there is no such field.
+    // get_field_by_id returns the request field or nullptr if there is no such field.
     inline Field* get_field_by_id(unsigned int id);
     inline const Field* get_field_by_id(unsigned int id) const;
 

--- a/src/dclass/dc/File.ipp
+++ b/src/dclass/dc/File.ipp
@@ -46,7 +46,7 @@ inline size_t File::get_num_types() const
 	return m_types_by_id.size();
 }
 
-// get_type_by_id returns the requested type or NULL if there is no such type.
+// get_type_by_id returns the requested type or nullptr if there is no such type.
 inline DistributedType* File::get_type_by_id(unsigned int id)
 {
 	if(id < m_types_by_id.size())
@@ -54,7 +54,7 @@ inline DistributedType* File::get_type_by_id(unsigned int id)
 		return m_types_by_id[id];
 	}
 
-	return (DistributedType*)NULL;
+	return nullptr;
 }
 inline const DistributedType* File::get_type_by_id(unsigned int id) const
 {
@@ -63,9 +63,9 @@ inline const DistributedType* File::get_type_by_id(unsigned int id) const
 		return m_types_by_id[id];
 	}
 
-	return (const DistributedType*)NULL;
+	return nullptr;
 }
-// get_type_by_name returns the requested type or NULL if there is no such type.
+// get_type_by_name returns the requested type or nullptr if there is no such type.
 inline DistributedType* File::get_type_by_name(const std::string &name)
 {
 	auto type_ref = m_types_by_name.find(name);
@@ -74,7 +74,7 @@ inline DistributedType* File::get_type_by_name(const std::string &name)
 		return type_ref->second;
 	}
 
-	return (DistributedType*)NULL;
+	return nullptr;
 }
 inline const DistributedType* File::get_type_by_name(const std::string &name) const
 {
@@ -84,10 +84,10 @@ inline const DistributedType* File::get_type_by_name(const std::string &name) co
 		return type_ref->second;
 	}
 
-	return (const DistributedType*)NULL;
+	return nullptr;
 }
 
-// get_field_by_id returns the request field or NULL if there is no such field.
+// get_field_by_id returns the request field or nullptr if there is no such field.
 inline Field* File::get_field_by_id(unsigned int id)
 {
 	if(id < m_fields_by_id.size())
@@ -95,7 +95,7 @@ inline Field* File::get_field_by_id(unsigned int id)
 		return m_fields_by_id[id];
 	}
 
-	return (Field*)NULL;
+	return nullptr;
 }
 inline const Field* File::get_field_by_id(unsigned int id) const
 {
@@ -104,7 +104,7 @@ inline const Field* File::get_field_by_id(unsigned int id) const
 		return m_fields_by_id[id];
 	}
 
-	return (const Field*)NULL;
+	return nullptr;
 }
 
 // get_num_imports returns the number of imports in the file.

--- a/src/dclass/dc/Method.cpp
+++ b/src/dclass/dc/Method.cpp
@@ -23,7 +23,7 @@ Method::~Method()
     m_parameters.clear();
 }
 
-// as_method returns this as a Method if it is a method, or NULL otherwise.
+// as_method returns this as a Method if it is a method, or nullptr otherwise.
 Method* Method::as_method()
 {
     return this;
@@ -37,7 +37,7 @@ const Method* Method::as_method() const
 bool Method::add_parameter(Parameter *param)
 {
     // Param should not be null
-    if(param == (Parameter*)NULL) {
+    if(param == nullptr) {
         return false;
     }
 

--- a/src/dclass/dc/Method.h
+++ b/src/dclass/dc/Method.h
@@ -18,7 +18,7 @@ class Method : public DistributedType
     Method();
     virtual ~Method();
 
-    // as_method returns this as a Method if it is a method, or NULL otherwise.
+    // as_method returns this as a Method if it is a method, or nullptr otherwise.
     virtual Method* as_method();
     virtual const Method* as_method() const;
 
@@ -27,7 +27,7 @@ class Method : public DistributedType
     // get_par returns the <n>th parameter of the method.
     inline Parameter* get_parameter(unsigned int n);
     inline const Parameter* get_parameter(unsigned int n) const;
-    // get_parameter_by_name returns the requested parameter or NULL if there is no such param.
+    // get_parameter_by_name returns the requested parameter or nullptr if there is no such param.
     inline Parameter* get_parameter_by_name(const std::string& name);
     inline const Parameter* get_parameter_by_name(const std::string& name) const;
 

--- a/src/dclass/dc/Method.ipp
+++ b/src/dclass/dc/Method.ipp
@@ -18,13 +18,13 @@ inline const Parameter* Method::get_parameter(unsigned int n) const\
 	return m_parameters.at(n);
 }
 
-// get_parameter_by_name returns the parameter with <name>, or NULL if no such param exists.
+// get_parameter_by_name returns the parameter with <name>, or nullptr if no such param exists.
 inline Parameter* Method::get_parameter_by_name(const std::string& name)
 {
 	auto it = m_parameters_by_name.find(name);
 	if(it == m_parameters_by_name.end())
 	{
-		return (Parameter*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }
@@ -33,7 +33,7 @@ inline const Parameter* Method::get_parameter_by_name(const std::string& name) c
 	auto it = m_parameters_by_name.find(name);
 	if(it == m_parameters_by_name.end())
 	{
-		return (Parameter*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }

--- a/src/dclass/dc/MolecularField.cpp
+++ b/src/dclass/dc/MolecularField.cpp
@@ -9,7 +9,7 @@ namespace dclass   // open namespace dclass
 
 // constructor
 MolecularField::MolecularField(Class* cls, const std::string &name) :
-    Field(NULL, name), Struct(cls->get_file())
+    Field(nullptr, name), Struct(cls->get_file())
 {
     Field::m_type = this;
 }
@@ -19,7 +19,7 @@ MolecularField::~MolecularField()
 {
 }
 
-// as_molecular returns this as a MolecularField if it is molecular, or NULL otherwise.
+// as_molecular returns this as a MolecularField if it is molecular, or nullptr otherwise.
 MolecularField* MolecularField::as_molecular()
 {
     return this;

--- a/src/dclass/dc/MolecularField.h
+++ b/src/dclass/dc/MolecularField.h
@@ -14,7 +14,7 @@ class MolecularField : public Field, public Struct
     MolecularField(Class* cls, const std::string &name);
     virtual ~MolecularField();
 
-    // as_molecular returns this as a MolecularField if it is molecular, or NULL otherwise.
+    // as_molecular returns this as a MolecularField if it is molecular, or nullptr otherwise.
     virtual MolecularField* as_molecular();
     virtual const MolecularField* as_molecular() const;
 

--- a/src/dclass/dc/NumericType.cpp
+++ b/src/dclass/dc/NumericType.cpp
@@ -48,7 +48,7 @@ NumericType::NumericType(Type type) :
     }
 }
 
-// as_numeric returns this as a NumericType if it is numeric, or NULL otherwise.
+// as_numeric returns this as a NumericType if it is numeric, or nullptr otherwise.
 NumericType* NumericType::as_numeric()
 {
     return this;

--- a/src/dclass/dc/NumericType.h
+++ b/src/dclass/dc/NumericType.h
@@ -16,7 +16,7 @@ class NumericType : public DistributedType
     // Type constructor
     NumericType(Type type);
 
-    // as_numeric returns this as a NumericType if it is numeric, or NULL otherwise.
+    // as_numeric returns this as a NumericType if it is numeric, or nullptr otherwise.
     virtual NumericType* as_numeric();
     virtual const NumericType* as_numeric() const;
 

--- a/src/dclass/dc/Parameter.cpp
+++ b/src/dclass/dc/Parameter.cpp
@@ -11,13 +11,13 @@ namespace dclass   // open namespace dclass
 
 // constructor
 Parameter::Parameter(DistributedType* type, const std::string& name) :
-    m_name(name), m_type(type), m_method(NULL), m_has_default_value(false)
+    m_name(name), m_type(type), m_method(nullptr), m_has_default_value(false)
 {
     bool implicit_value;
     m_default_value = create_default_value(type, implicit_value);
     m_has_default_value = !implicit_value;
 
-    if(m_type == NULL) {
+    if(m_type == nullptr) {
         m_type = DistributedType::invalid;
     }
 }
@@ -27,7 +27,7 @@ Parameter::Parameter(DistributedType* type, const std::string& name) :
 bool Parameter::set_name(const std::string& name)
 {
     // Check to make sure no other fields in our struct have this name
-    if(m_method != (Method*)NULL && m_method->get_parameter_by_name(name) != (Parameter*)NULL) {
+    if(m_method != nullptr && m_method->get_parameter_by_name(name) != nullptr) {
         return false;
     }
 
@@ -38,7 +38,7 @@ bool Parameter::set_name(const std::string& name)
 // set_type sets the distributed type of the parameter and clear's the default value.
 bool Parameter::set_type(DistributedType* type)
 {
-    if(type == (DistributedType*)NULL) {
+    if(type == nullptr) {
         return false;
     }
 

--- a/src/dclass/dc/Struct.cpp
+++ b/src/dclass/dc/Struct.cpp
@@ -28,7 +28,7 @@ Struct::~Struct()
     }
 }
 
-// as_struct returns this as a Struct if it is a Struct, or NULL otherwise.
+// as_struct returns this as a Struct if it is a Struct, or nullptr otherwise.
 Struct* Struct::as_struct()
 {
     return this;
@@ -38,26 +38,26 @@ const Struct* Struct::as_struct() const
     return this;
 }
 
-// as_class returns this Struct as a Class if it is a Class, or NULL otherwise.
+// as_class returns this Struct as a Class if it is a Class, or nullptr otherwise.
 Class* Struct::as_class()
 {
-    return (Class*)NULL;
+    return nullptr;
 }
 const Class* Struct::as_class() const
 {
-    return (const Class*)NULL;
+    return nullptr;
 }
 
 // add_field adds a new Field to the struct.
 bool Struct::add_field(Field* field)
 {
     // Field must not be null
-    if(field == (Field*)NULL) {
+    if(field == nullptr) {
         return false;
     }
 
     // Structs can't share a field
-    if(field->get_struct() != NULL && field->get_struct() != this) {
+    if(field->get_struct() != nullptr && field->get_struct() != this) {
         return false;
     }
 

--- a/src/dclass/dc/Struct.h
+++ b/src/dclass/dc/Struct.h
@@ -23,11 +23,11 @@ class Struct : public DistributedType
     Struct(File* file, const std::string &name);
     virtual ~Struct();
 
-    // as_struct returns this as a Struct if it is a Struct, or NULL otherwise.
+    // as_struct returns this as a Struct if it is a Struct, or nullptr otherwise.
     virtual Struct* as_struct();
     virtual const Struct* as_struct() const;
 
-    // as_class returns this Struct as a Class if it is a Class, or NULL otherwise.
+    // as_class returns this Struct as a Class if it is a Class, or nullptr otherwise.
     virtual Class* as_class();
     virtual const Class* as_class() const;
 
@@ -45,10 +45,10 @@ class Struct : public DistributedType
     inline Field* get_field(unsigned int n);
     inline const Field* get_field(unsigned int n) const;
 
-    // get_field_by_id returns the field with the index <id>, or NULL if no such field exists.
+    // get_field_by_id returns the field with the index <id>, or nullptr if no such field exists.
     inline Field* get_field_by_id(unsigned int id);
     inline const Field* get_field_by_id(unsigned int id) const;
-    // get_field_by_name returns the field with <name>, or NULL if no such field exists.
+    // get_field_by_name returns the field with <name>, or nullptr if no such field exists.
     inline Field* get_field_by_name(const std::string& name);
     inline const Field* get_field_by_name(const std::string& name) const;
 

--- a/src/dclass/dc/Struct.ipp
+++ b/src/dclass/dc/Struct.ipp
@@ -32,7 +32,7 @@ inline size_t Struct::get_num_fields() const
 	return m_fields.size();
 }
 
-// get_field returns the <n>th field of the struct or NULL if out-of-range.
+// get_field returns the <n>th field of the struct or nullptr if out-of-range.
 inline Field* Struct::get_field(unsigned int n)
 {
 	return m_fields.at(n);
@@ -42,13 +42,13 @@ inline const Field* Struct::get_field(unsigned int n) const
 	return m_fields.at(n);
 }
 
-// get_field_by_id returns the field with the index <id>, or NULL if no such field exists.
+// get_field_by_id returns the field with the index <id>, or nullptr if no such field exists.
 inline Field* Struct::get_field_by_id(unsigned int id)
 {
 	auto it = m_fields_by_id.find(id);
 	if(it == m_fields_by_id.end())
 	{
-		return (Field*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }
@@ -57,18 +57,18 @@ inline const Field* Struct::get_field_by_id(unsigned int id) const
 	auto it = m_fields_by_id.find(id);
 	if(it == m_fields_by_id.end())
 	{
-		return (Field*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }
 
-// get_field_by_name returns the field with <name>, or NULL if no such field exists.
+// get_field_by_name returns the field with <name>, or nullptr if no such field exists.
 inline Field* Struct::get_field_by_name(const std::string& name)
 {
 	auto it = m_fields_by_name.find(name);
 	if(it == m_fields_by_name.end())
 	{
-		return (Field*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }
@@ -77,7 +77,7 @@ inline const Field* Struct::get_field_by_name(const std::string& name) const
 	auto it = m_fields_by_name.find(name);
 	if(it == m_fields_by_name.end())
 	{
-		return (Field*)NULL;
+		return nullptr;
 	}
 	return it->second;
 }

--- a/src/dclass/file/hash_legacy.cpp
+++ b/src/dclass/file/hash_legacy.cpp
@@ -182,7 +182,7 @@ void hash_keywords(HashGenerator& hashgen, const KeywordList* list)
         { "clrecv", 0x0040 },
         { "ownsend", 0x0080 },
         { "airecv", 0x0100 },
-        { NULL, 0 }
+        { nullptr, 0 }
     };
 
     size_t num_keywords = list->get_num_keywords();

--- a/src/dclass/file/lexer.cpp
+++ b/src/dclass/file/lexer.cpp
@@ -35,7 +35,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -52,7 +52,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -170,7 +170,7 @@ extern FILE *yyin, *yyout;
 
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -227,7 +227,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -261,14 +261,14 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
  * future we want to put the buffer states in a more general
  * "scanner state".
  *
- * Returns the top of the stack, or NULL.
+ * Returns the top of the stack, or nullptr.
  */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
-                          : NULL)
+                          : nullptr)
 
 /* Same as previous macro, but useful when we know that the buffer stack is not
- * NULL or when we need an lvalue. For internal use only.
+ * nullptr or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
@@ -569,7 +569,7 @@ char *yytext;
 	static int warning_count = 0;
 
 	// This is the pointer to the current input stream.
-	static std::istream *input_p = NULL;
+	static std::istream *input_p = nullptr;
 
 	// This is the name of the dc file we're parsing.  We keep it so we
 	// can print it out for error messages.
@@ -676,7 +676,7 @@ char *yytext;
 
 				// Truncate it at the newline.
 				char *end = strchr(current_line, '\n');
-				if(end != NULL)
+				if(end != nullptr)
 				{
 					*end = '\0';
 				}
@@ -1145,7 +1145,7 @@ YY_DECL
 	 yy_state_type yy_current_state;
 	 char *yy_cp, *yy_bp;
 	 int yy_act;
-    
+
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -1841,7 +1841,7 @@ static int yy_get_next_buffer (void)
 {
 	 yy_state_type yy_current_state;
 	 char *yy_cp;
-    
+
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
@@ -1900,7 +1900,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-    
+
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -1967,12 +1967,12 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ *
  * @note This function does not reset the start condition to @c INITIAL .
  */
     void yyrestart  (FILE * input_file )
 {
-    
+
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -1985,11 +1985,11 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ *
  */
     void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-    
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
@@ -2029,13 +2029,13 @@ static void yy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ *
  * @return the allocated buffer state.
  */
     YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
@@ -2058,11 +2058,11 @@ static void yy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with yy_create_buffer()
- * 
+ *
  */
     void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
-    
+
 	if ( ! b )
 		return;
 
@@ -2083,7 +2083,7 @@ static void yy_load_buffer_state  (void)
 
 {
 	int oerrno = errno;
-    
+
 	yy_flush_buffer(b );
 
 	b->yy_input_file = file;
@@ -2099,13 +2099,13 @@ static void yy_load_buffer_state  (void)
     }
 
         b->yy_is_interactive = 0;
-    
+
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ *
  */
     void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
@@ -2134,11 +2134,11 @@ static void yy_load_buffer_state  (void)
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *
  */
 void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
-    	if (new_buffer == NULL)
+	if (new_buffer == nullptr)
 		return;
 
 	yyensure_buffer_stack();
@@ -2164,7 +2164,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *
  */
 void yypop_buffer_state (void)
 {
@@ -2172,7 +2172,7 @@ void yypop_buffer_state (void)
 		return;
 
 	yy_delete_buffer(YY_CURRENT_BUFFER );
-	YY_CURRENT_BUFFER_LVALUE = NULL;
+	YY_CURRENT_BUFFER_LVALUE = nullptr;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
@@ -2188,7 +2188,7 @@ void yypop_buffer_state (void)
 static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
-    
+
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -2201,9 +2201,9 @@ static void yyensure_buffer_stack (void)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2231,13 +2231,13 @@ static void yyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
- * @return the newly allocated buffer state object. 
+ *
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -2266,14 +2266,14 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ *
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
 YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
 {
-    
+
 	return yy_scan_bytes(yystr,strlen(yystr) );
 }
 
@@ -2281,7 +2281,7 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ *
  * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
@@ -2290,7 +2290,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 	char *buf;
 	yy_size_t n;
 	yy_size_t i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) yyalloc(n  );
@@ -2344,16 +2344,16 @@ static void yy_fatal_error (yyconst char* msg )
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- * 
+ *
  */
 int yyget_lineno  (void)
 {
-        
+
     return yylineno;
 }
 
 /** Get the input stream.
- * 
+ *
  */
 FILE *yyget_in  (void)
 {
@@ -2361,7 +2361,7 @@ FILE *yyget_in  (void)
 }
 
 /** Get the output stream.
- * 
+ *
  */
 FILE *yyget_out  (void)
 {
@@ -2369,7 +2369,7 @@ FILE *yyget_out  (void)
 }
 
 /** Get the length of the current token.
- * 
+ *
  */
 yy_size_t yyget_leng  (void)
 {
@@ -2377,7 +2377,7 @@ yy_size_t yyget_leng  (void)
 }
 
 /** Get the current token.
- * 
+ *
  */
 
 char *yyget_text  (void)
@@ -2387,18 +2387,18 @@ char *yyget_text  (void)
 
 /** Set the current line number.
  * @param line_number
- * 
+ *
  */
 void yyset_lineno (int  line_number )
 {
-    
+
     yylineno = line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param in_str A readable stream.
- * 
+ *
  * @see yy_switch_to_buffer
  */
 void yyset_in (FILE *  in_str )
@@ -2452,17 +2452,17 @@ static int yy_init_globals (void)
 /* yylex_destroy is for both reentrant and non-reentrant scanners. */
 int yylex_destroy  (void)
 {
-    
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		yy_delete_buffer(YY_CURRENT_BUFFER  );
-		YY_CURRENT_BUFFER_LVALUE = NULL;
+		YY_CURRENT_BUFFER_LVALUE = nullptr;
 		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
 	yyfree((yy_buffer_stack) );
-	(yy_buffer_stack) = NULL;
+	(yy_buffer_stack) = nullptr;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
      * yylex() is called, initialization will occur. */

--- a/src/dclass/file/lexer.lpp
+++ b/src/dclass/file/lexer.lpp
@@ -42,7 +42,7 @@
 	static int warning_count = 0;
 
 	// This is the pointer to the current input stream.
-	static std::istream *input_p = NULL;
+	static std::istream *input_p = nullptr;
 
 	// This is the name of the dc file we're parsing.  We keep it so we
 	// can print it out for error messages.
@@ -149,7 +149,7 @@
 
 				// Truncate it at the newline.
 				char *end = strchr(current_line, '\n');
-				if(end != NULL)
+				if(end != nullptr)
 				{
 					*end = '\0';
 				}

--- a/src/dclass/file/parser.cpp
+++ b/src/dclass/file/parser.cpp
@@ -109,12 +109,12 @@
 
 
 	// Parser output
-	static File* parsed_file = (File*)NULL;
-	static string* parsed_value = (string*)NULL;
+	static File* parsed_file = nullptr;
+	static string* parsed_value = nullptr;
 
 	// Parser state
-	static Class* current_class = (Class*)NULL;
-	static Struct* current_struct = (Struct*)NULL;
+	static Class* current_class = nullptr;
+	static Struct* current_struct = nullptr;
 
 	// Stack of distributed types for parsing values
 	struct TypeAndDepth
@@ -128,8 +128,8 @@
 
 	// These two types are really common types the parser doesn't need to make new
 	//     duplicates of every time a string or blob is used.
-	static ArrayType* basic_string = (ArrayType*)NULL;
-	static ArrayType* basic_blob = (ArrayType*)NULL;
+	static ArrayType* basic_string = nullptr;
+	static ArrayType* basic_blob = nullptr;
 
 	/* Helper functions */
 	static bool check_depth();
@@ -162,8 +162,8 @@
 	{
 		current_depth = 0;
 		type_stack = stack<TypeAndDepth>();
-		parsed_file = (File*)NULL;
-		parsed_value = (string*)NULL;
+		parsed_file = nullptr;
+		parsed_value = nullptr;
 	}
 
 	int parser_error_count()
@@ -1664,7 +1664,7 @@ yyreduce:
   case 24:
 #line 316 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[0].nametype).type == (DistributedType*)NULL)
+		if((yyvsp[0].nametype).type == nullptr)
 		{
 			// Ignore this typedef, it should have already produced an error
 			break;
@@ -1678,14 +1678,14 @@ yyreduce:
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name((yyvsp[0].nametype).name);
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding typedef to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'typedef " + (yyvsp[0].nametype).name
 				             + "' to file because a typedef was already declared with that name.");
@@ -1739,10 +1739,10 @@ yyreduce:
 #line 383 "parser.ypp" /* yacc.c:1646  */
     {
 		DistributedType* dtype = parsed_file->get_type_by_name((yyvsp[0].str));
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			parser_error("Type '" + string((yyvsp[0].str)) + "' has not been declared.");
-			(yyval.u.dtype) = NULL;
+			(yyval.u.dtype) = nullptr;
 			break;
 		}
 
@@ -1775,14 +1775,14 @@ yyreduce:
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name(current_class->get_name());
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding class to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'dclass " + current_class->get_name()
 				             + "' to file because a typedef was already declared with that name.");
@@ -1807,7 +1807,7 @@ yyreduce:
   case 36:
 #line 455 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[0].u.dclass) != (Class*)NULL)
+		if((yyvsp[0].u.dclass) != nullptr)
 		{
 			current_class->add_parent((yyvsp[0].u.dclass));
 		}
@@ -1818,7 +1818,7 @@ yyreduce:
   case 37:
 #line 462 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[0].u.dclass) != (Class*)NULL)
+		if((yyvsp[0].u.dclass) != nullptr)
 		{
 			current_class->add_parent((yyvsp[0].u.dclass));
 		}
@@ -1830,26 +1830,26 @@ yyreduce:
 #line 472 "parser.ypp" /* yacc.c:1646  */
     {
 		DistributedType* dtype = parsed_file->get_type_by_name((yyvsp[0].str));
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			parser_error("'dclass " + string((yyvsp[0].str)) + "' has not been declared.");
-			(yyval.u.dclass) = NULL;
+			(yyval.u.dclass) = nullptr;
 			break;
 		}
 
 		Struct* dstruct = dtype->as_struct();
-		if(dstruct == (Struct*)NULL)
+		if(dstruct == nullptr)
 		{
 			parser_error("class cannot inherit from non-class type '" + string((yyvsp[0].str)) + "'.");
-			(yyval.u.dclass) = NULL;
+			(yyval.u.dclass) = nullptr;
 			break;
 		}
 
 		Class* dclass = dstruct->as_class();
-		if(dclass == (Class*)NULL)
+		if(dclass == nullptr)
 		{
 			parser_error("class cannot inherit from struct type '" + string((yyvsp[0].str)) + "'.");
-			(yyval.u.dclass) = NULL;
+			(yyval.u.dclass) = nullptr;
 			break;
 		}
 
@@ -1861,7 +1861,7 @@ yyreduce:
   case 41:
 #line 505 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[-1].u.dfield) == (Field*)NULL)
+		if((yyvsp[-1].u.dfield) == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
 			break;
@@ -1900,17 +1900,17 @@ yyreduce:
   case 42:
 #line 543 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[-1].u.dfield) == (Field*)NULL)
+		if((yyvsp[-1].u.dfield) == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
-			(yyval.u.dfield) = NULL;
+			(yyval.u.dfield) = nullptr;
 			break;
 		}
 
 		if((yyvsp[-1].u.dfield)->get_name().empty())
 		{
 			parser_error("An unnamed field can't be defined in a class.");
-			(yyval.u.dfield) = NULL;
+			(yyval.u.dfield) = nullptr;
 			break;
 		}
 
@@ -1949,14 +1949,14 @@ yyreduce:
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name(current_struct->get_name());
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding struct to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'struct " + current_struct->get_name()
 				             + "' to file because a typedef was already declared with that name.");
@@ -1981,7 +1981,7 @@ yyreduce:
   case 48:
 #line 616 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[-1].u.dfield) == (Field*)NULL || (yyvsp[-1].u.dfield)->get_type() == (DistributedType*)NULL)
+		if((yyvsp[-1].u.dfield) == nullptr || (yyvsp[-1].u.dfield)->get_type() == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
 			break;
@@ -2135,17 +2135,17 @@ yyreduce:
   case 70:
 #line 749 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[0].u.dtype) == (DistributedType*)NULL)
+		if((yyvsp[0].u.dtype) == nullptr)
 		{
-			// defined_type should have output an error, pass NULL upstream
-			(yyval.u.dtype) = NULL;
+			// defined_type should have output an error, pass nullptr upstream
+			(yyval.u.dtype) = nullptr;
 			break;
 		}
 
 		if((yyvsp[0].u.dtype)->get_type() == T_METHOD)
 		{
 			parser_error("Cannot use a method type here.");
-			(yyval.u.dtype) = NULL;
+			(yyval.u.dtype) = nullptr;
 			break;
 		}
 
@@ -2198,7 +2198,7 @@ yyreduce:
 #line 794 "parser.ypp" /* yacc.c:1646  */
     {
 		MolecularField* mol = new MolecularField(current_class, (yyvsp[-2].str));
-		if((yyvsp[0].u.dfield) == (Field*)NULL)
+		if((yyvsp[0].u.dfield) == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.u.dmolecule) = mol;
@@ -2227,7 +2227,7 @@ yyreduce:
   case 78:
 #line 820 "parser.ypp" /* yacc.c:1646  */
     {
-		if((yyvsp[0].u.dfield) == (Field*)NULL)
+		if((yyvsp[0].u.dfield) == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.u.dmolecule) = (yyvsp[-2].u.dmolecule);
@@ -2264,15 +2264,15 @@ yyreduce:
 		if(!current_class)
 		{
 			parser_error("Field '" + (yyvsp[0].str) + "' not defined in current class.");
-			(yyval.u.dfield) = NULL;
+			(yyval.u.dfield) = nullptr;
 			break;
 		}
 
 		Field *field = current_class->get_field_by_name((yyvsp[0].str));
-		if(field == (Field*)NULL)
+		if(field == nullptr)
 		{
 			parser_error("Field '" + (yyvsp[0].str) + "' not defined in current class.");
-			(yyval.u.dfield) = NULL;
+			(yyval.u.dfield) = nullptr;
 			break;
 		}
 
@@ -2286,7 +2286,7 @@ yyreduce:
     {
 		if((yyvsp[0].u.type) == T_STRING)
 		{
-			if(basic_string == NULL)
+			if(basic_string == nullptr)
 			{
 				basic_string = new ArrayType(new NumericType(T_CHAR));
 				basic_string->set_alias("string");
@@ -2296,7 +2296,7 @@ yyreduce:
 		}
 		else if((yyvsp[0].u.type) == T_BLOB)
 		{
-			if(basic_blob == NULL)
+			if(basic_blob == nullptr)
 			{
 				basic_blob = new ArrayType(new NumericType(T_UINT8));
 				basic_blob->set_alias("blob");
@@ -2307,7 +2307,7 @@ yyreduce:
 		else
 		{
 			parser_error("Found builtin ArrayType not handled by parser.");
-			(yyval.u.dtype) = NULL;
+			(yyval.u.dtype) = nullptr;
 		}
 	}
 #line 2314 "parser.cpp" /* yacc.c:1646  */
@@ -2331,7 +2331,7 @@ yyreduce:
 		else
 		{
 			parser_error("Found builtin ArrayType not handled by parser.");
-			(yyval.u.dtype) = NULL;
+			(yyval.u.dtype) = nullptr;
 		}
 	}
 #line 2338 "parser.cpp" /* yacc.c:1646  */
@@ -2653,7 +2653,7 @@ yyreduce:
 		if(!check_depth()) depth_error("signed integer");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2672,7 +2672,7 @@ yyreduce:
 		if(!check_depth()) depth_error("unsigned integer");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2691,7 +2691,7 @@ yyreduce:
 		if(!check_depth()) depth_error("floating point");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2710,7 +2710,7 @@ yyreduce:
 		if(!check_depth()) depth_error("string");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2751,7 +2751,7 @@ yyreduce:
 		if(!check_depth()) depth_error("hex-string");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2789,7 +2789,7 @@ yyreduce:
 		if(!check_depth()) depth_error("method");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -2844,7 +2844,7 @@ yyreduce:
 		if(!check_depth()) depth_error("struct");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -2907,7 +2907,7 @@ yyreduce:
 		if(!check_depth()) depth_error("array");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -2955,7 +2955,7 @@ yyreduce:
 		if(!check_depth()) depth_error("array");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -2988,7 +2988,7 @@ yyreduce:
 			uint64_t actual_size = current_depth - type_stack.top().depth;
 
 			const DistributedType* dtype = type_stack.top().type;
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				// Ignore this field, it should have already generated an error
 				(yyval.str) = "";
@@ -3034,7 +3034,7 @@ yyreduce:
 		// Don't increment the depth; the array_expansion will add to
 		// the current_depth depending on the number of elements it adds.
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -3066,7 +3066,7 @@ yyreduce:
 #line 1528 "parser.ypp" /* yacc.c:1646  */
     {
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -3092,7 +3092,7 @@ yyreduce:
 #line 1550 "parser.ypp" /* yacc.c:1646  */
     {
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -3118,7 +3118,7 @@ yyreduce:
 #line 1572 "parser.ypp" /* yacc.c:1646  */
     {
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -3144,7 +3144,7 @@ yyreduce:
 #line 1594 "parser.ypp" /* yacc.c:1646  */
     {
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -3204,7 +3204,7 @@ yyreduce:
 #line 1650 "parser.ypp" /* yacc.c:1646  */
     {
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			(yyval.str) = "";
@@ -3620,7 +3620,7 @@ void depth_error(string what)
 	}
 	else
 	{
-		parser_error("Too few nested values while parsing value for " + what + ".");	
+		parser_error("Too few nested values while parsing value for " + what + ".");
 	}
 }
 

--- a/src/dclass/file/parser.ypp
+++ b/src/dclass/file/parser.ypp
@@ -47,12 +47,12 @@
 
 
 	// Parser output
-	static File* parsed_file = (File*)NULL;
-	static string* parsed_value = (string*)NULL;
+	static File* parsed_file = nullptr;
+	static string* parsed_value = nullptr;
 
 	// Parser state
-	static Class* current_class = (Class*)NULL;
-	static Struct* current_struct = (Struct*)NULL;
+	static Class* current_class = nullptr;
+	static Struct* current_struct = nullptr;
 
 	// Stack of distributed types for parsing values
 	struct TypeAndDepth
@@ -66,8 +66,8 @@
 
 	// These two types are really common types the parser doesn't need to make new
 	//     duplicates of every time a string or blob is used.
-	static ArrayType* basic_string = (ArrayType*)NULL;
-	static ArrayType* basic_blob = (ArrayType*)NULL;
+	static ArrayType* basic_string = nullptr;
+	static ArrayType* basic_blob = nullptr;
 
 	/* Helper functions */
 	static bool check_depth();
@@ -100,8 +100,8 @@
 	{
 		current_depth = 0;
 		type_stack = stack<TypeAndDepth>();
-		parsed_file = (File*)NULL;
-		parsed_value = (string*)NULL;
+		parsed_file = nullptr;
+		parsed_value = nullptr;
 	}
 
 	int parser_error_count()
@@ -314,7 +314,7 @@ import_alternatives
 typedef
 	: typedef_type
 	{
-		if($1.type == (DistributedType*)NULL)
+		if($1.type == nullptr)
 		{
 			// Ignore this typedef, it should have already produced an error
 			break;
@@ -328,14 +328,14 @@ typedef
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name($1.name);
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding typedef to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'typedef " + $1.name
 				             + "' to file because a typedef was already declared with that name.");
@@ -382,10 +382,10 @@ defined_type
 	: IDENTIFIER
 	{
 		DistributedType* dtype = parsed_file->get_type_by_name($1);
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			parser_error("Type '" + string($1) + "' has not been declared.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
@@ -417,14 +417,14 @@ dclass
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name(current_class->get_name());
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding class to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'dclass " + current_class->get_name()
 				             + "' to file because a typedef was already declared with that name.");
@@ -453,14 +453,14 @@ class_inheritance
 class_parents
 	: defined_class
 	{
-		if($1 != (Class*)NULL)
+		if($1 != nullptr)
 		{
 			current_class->add_parent($1);
 		}
 	}
 	| class_parents ',' defined_class
 	{
-		if($3 != (Class*)NULL)
+		if($3 != nullptr)
 		{
 			current_class->add_parent($3);
 		}
@@ -471,26 +471,26 @@ defined_class
 	: IDENTIFIER
 	{
 		DistributedType* dtype = parsed_file->get_type_by_name($1);
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			parser_error("'dclass " + string($1) + "' has not been declared.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
 		Struct* dstruct = dtype->as_struct();
-		if(dstruct == (Struct*)NULL)
+		if(dstruct == nullptr)
 		{
 			parser_error("class cannot inherit from non-class type '" + string($1) + "'.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
 		Class* dclass = dstruct->as_class();
-		if(dclass == (Class*)NULL)
+		if(dclass == nullptr)
 		{
 			parser_error("class cannot inherit from struct type '" + string($1) + "'.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
@@ -503,7 +503,7 @@ class_fields
 	| class_fields ';'
 	| class_fields class_field ';'
 	{
-		if($2 == (Field*)NULL)
+		if($2 == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
 			break;
@@ -541,17 +541,17 @@ class_fields
 class_field
 	: named_field keyword_list
 	{
-		if($1 == (Field*)NULL)
+		if($1 == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
 		if($1->get_name().empty())
 		{
 			parser_error("An unnamed field can't be defined in a class.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
@@ -581,14 +581,14 @@ dstruct
 		{
 			// Lets be really descriptive about why this failed
 			DistributedType* dtype = parsed_file->get_type_by_name(current_struct->get_name());
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				parser_error("Unknown error adding struct to file.");
 				break;
 			}
 
 			Struct* dstruct = dtype->as_struct();
-			if(dstruct == (Struct*)NULL)
+			if(dstruct == nullptr)
 			{
 				parser_error("Cannot add 'struct " + current_struct->get_name()
 				             + "' to file because a typedef was already declared with that name.");
@@ -614,7 +614,7 @@ struct_fields
 	| struct_fields ';'
 	| struct_fields struct_field ';'
 	{
-		if($2 == (Field*)NULL || $2->get_type() == (DistributedType*)NULL)
+		if($2 == nullptr || $2->get_type() == nullptr)
 		{
 			// Ignore this field, it should have already generated a parser error
 			break;
@@ -697,7 +697,7 @@ field_with_name_as_array
 	;
 
 field_with_name_and_default
-	: field_with_name '=' 
+	: field_with_name '='
 	{
 		current_depth = 0;
 		type_stack.push(TypeAndDepth($1->get_type(), 0));
@@ -747,17 +747,17 @@ nonmethod_type
 nonmethod_type_no_array
 	: defined_type
 	{
-		if($1 == (DistributedType*)NULL)
+		if($1 == nullptr)
 		{
-			// defined_type should have output an error, pass NULL upstream
-			$$ = NULL;
+			// defined_type should have output an error, pass nullptr upstream
+			$$ = nullptr;
 			break;
 		}
 
 		if($1->get_type() == T_METHOD)
 		{
 			parser_error("Cannot use a method type here.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
@@ -793,7 +793,7 @@ molecular
 	: IDENTIFIER ':' defined_field
 	{
 		MolecularField* mol = new MolecularField(current_class, $1);
-		if($3 == (Field*)NULL)
+		if($3 == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = mol;
@@ -818,7 +818,7 @@ molecular
 	}
 	| molecular ',' defined_field
 	{
-		if($3 == (Field*)NULL)
+		if($3 == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = $1;
@@ -853,15 +853,15 @@ defined_field
 		if(!current_class)
 		{
 			parser_error("Field '" + $1 + "' not defined in current class.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
 		Field *field = current_class->get_field_by_name($1);
-		if(field == (Field*)NULL)
+		if(field == nullptr)
 		{
 			parser_error("Field '" + $1 + "' not defined in current class.");
-			$$ = NULL;
+			$$ = nullptr;
 			break;
 		}
 
@@ -874,7 +874,7 @@ builtin_array_type
 	{
 		if($1 == T_STRING)
 		{
-			if(basic_string == NULL)
+			if(basic_string == nullptr)
 			{
 				basic_string = new ArrayType(new NumericType(T_CHAR));
 				basic_string->set_alias("string");
@@ -884,7 +884,7 @@ builtin_array_type
 		}
 		else if($1 == T_BLOB)
 		{
-			if(basic_blob == NULL)
+			if(basic_blob == nullptr)
 			{
 				basic_blob = new ArrayType(new NumericType(T_UINT8));
 				basic_blob->set_alias("blob");
@@ -895,7 +895,7 @@ builtin_array_type
 		else
 		{
 			parser_error("Found builtin ArrayType not handled by parser.");
-			$$ = NULL;
+			$$ = nullptr;
 		}
 	}
 	| array_type_token '(' array_range ')'
@@ -915,7 +915,7 @@ builtin_array_type
 		else
 		{
 			parser_error("Found builtin ArrayType not handled by parser.");
-			$$ = NULL;
+			$$ = nullptr;
 		}
 	}
 	;
@@ -1032,7 +1032,7 @@ parameter
 	{
 		$$ = new Parameter($1);
 	}
-	| nonmethod_type '=' 
+	| nonmethod_type '='
 	{
 		current_depth = 0;
 		type_stack.push(TypeAndDepth($1,0));
@@ -1159,7 +1159,7 @@ type_value
 		if(!check_depth()) depth_error("signed integer");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1174,7 +1174,7 @@ type_value
 		if(!check_depth()) depth_error("unsigned integer");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1189,7 +1189,7 @@ type_value
 		if(!check_depth()) depth_error("floating point");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1204,7 +1204,7 @@ type_value
 		if(!check_depth()) depth_error("string");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1241,7 +1241,7 @@ type_value
 		if(!check_depth()) depth_error("hex-string");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1280,7 +1280,7 @@ method_value
 		if(!check_depth()) depth_error("method");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -1330,7 +1330,7 @@ struct_value
 		if(!check_depth()) depth_error("struct");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -1385,7 +1385,7 @@ array_value
 		if(!check_depth()) depth_error("array");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1429,7 +1429,7 @@ array_value
 		if(!check_depth()) depth_error("array");
 
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -1458,7 +1458,7 @@ array_value
 			uint64_t actual_size = current_depth - type_stack.top().depth;
 
 			const DistributedType* dtype = type_stack.top().type;
-			if(dtype == (DistributedType*)NULL)
+			if(dtype == nullptr)
 			{
 				// Ignore this field, it should have already generated an error
 				$$ = "";
@@ -1498,13 +1498,13 @@ array_value
 
 element_values
 	: array_expansion
-	| element_values ',' 
+	| element_values ','
 	{
 		// We popped off the only element we added, so we're back to the array
 		// Don't increment the depth; the array_expansion will add to
 		// the current_depth depending on the number of elements it adds.
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			break;
@@ -1527,7 +1527,7 @@ array_expansion
 	| signed_integer '*' small_unsigned_integer
 	{
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1549,7 +1549,7 @@ array_expansion
 	| UNSIGNED_INTEGER '*' small_unsigned_integer
 	{
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1571,7 +1571,7 @@ array_expansion
 	| REAL '*' small_unsigned_integer
 	{
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1593,7 +1593,7 @@ array_expansion
 	| STRING '*' small_unsigned_integer
 	{
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1649,7 +1649,7 @@ array_expansion
 	| HEX_STRING '*' small_unsigned_integer
 	{
 		const DistributedType* dtype = type_stack.top().type;
-		if(dtype == (DistributedType*)NULL)
+		if(dtype == nullptr)
 		{
 			// Ignore this field, it should have already generated an error
 			$$ = "";
@@ -1767,7 +1767,7 @@ void depth_error(string what)
 	}
 	else
 	{
-		parser_error("Too few nested values while parsing value for " + what + ".");	
+		parser_error("Too few nested values while parsing value for " + what + ".");
 	}
 }
 

--- a/src/dclass/file/read.cpp
+++ b/src/dclass/file/read.cpp
@@ -41,7 +41,7 @@ File* read(istream &in, const string &filename)
         return f;
     }
 
-    return NULL;
+    return nullptr;
 }
 File* read(const string &filename)
 {
@@ -51,7 +51,7 @@ File* read(const string &filename)
         return f;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 

--- a/src/dclass/file/write.cpp
+++ b/src/dclass/file/write.cpp
@@ -217,7 +217,7 @@ void Parameter::write_typedef_name(ostream &out, bool brief, int indent_level,
 void SimpleParameter::output_instance(ostream &out, bool brief, const string &prename,
                                       const string &name, const string &postname) const
 {
-    if(get_typedef() != (Typedef *)NULL)
+    if(get_typedef() != nullptr)
     {
         output_typedef_name(out, brief, prename, name, postname);
 
@@ -320,7 +320,7 @@ void SimpleParameter::output_instance(ostream &out, bool brief, const string &pr
 void ArrayParameter::output_instance(ostream &out, bool brief, const string &prename,
                                      const string &name, const string &postname) const
 {
-    if(get_typedef() != (Typedef *)NULL)
+    if(get_typedef() != nullptr)
     {
         output_typedef_name(out, brief, prename, name, postname);
 
@@ -407,7 +407,7 @@ void Struct::write(ostream &out, bool brief, int indent_level) const
     out << "\n";
 
     // TODO: Move and update class writing
-    if(m_constructor != (Field*)NULL)
+    if(m_constructor != nullptr)
     {
         m_constructor->write(out, brief, indent_level + 2);
     }
@@ -468,7 +468,7 @@ void Struct::output_instance(ostream &out, bool brief, const string &prename,
 
     out << " {";
 
-    if(m_constructor != (Field*)NULL)
+    if(m_constructor != nullptr)
     {
         m_constructor->output(out, brief);
         out << "; ";

--- a/src/dclass/value/default.cpp
+++ b/src/dclass/value/default.cpp
@@ -24,7 +24,7 @@ string create_default_value(const DistributedType* dtype)
 //     or false otherwise (ie. at least one value was user-defined via set_default_value).
 string create_default_value(const DistributedType* dtype, bool& is_implicit)
 {
-    if(dtype == NULL) {
+    if(dtype == nullptr) {
         return "";
     }
 

--- a/src/messagedirector/MessageDirector.cpp
+++ b/src/messagedirector/MessageDirector.cpp
@@ -27,8 +27,8 @@ static ConfigVariable<std::string> daemon_url("url", "", daemon_config);
 MessageDirector MessageDirector::singleton;
 
 
-MessageDirector::MessageDirector() :  m_initialized(false), m_net_acceptor(NULL), m_upstream(NULL),
-    m_thread(NULL), m_main_thread(std::this_thread::get_id()), m_log("msgdir", "Message Director")
+MessageDirector::MessageDirector() :  m_initialized(false), m_net_acceptor(nullptr), m_upstream(nullptr),
+    m_thread(nullptr), m_main_thread(std::this_thread::get_id()), m_log("msgdir", "Message Director")
 {
 }
 
@@ -330,7 +330,7 @@ void MessageDirector::recall_post_removes(channel_t sender)
 
 void MessageDirector::receive_datagram(DatagramHandle dg)
 {
-    route_datagram(NULL, dg);
+    route_datagram(nullptr, dg);
 }
 
 void MessageDirector::receive_disconnect(const boost::system::error_code &ec)

--- a/src/net/NetworkConnector.h
+++ b/src/net/NetworkConnector.h
@@ -12,8 +12,8 @@ class NetworkConnector
 
     // Parses the string "address" and connects to it. If no port is specified
     // as part of the address, it will use default_port.
-    // The return value will either be a freshly-allocated socket, or NULL.
-    // If the return value is NULL, the error code will be set to indicate
+    // The return value will either be a freshly-allocated socket, or nullptr.
+    // If the return value is nullptr, the error code will be set to indicate
     // the reason that the connect failed.
     tcp::socket *connect(const std::string &address, unsigned int default_port,
                          boost::system::error_code &ec);

--- a/src/stateserver/LoadingObject.cpp
+++ b/src/stateserver/LoadingObject.cpp
@@ -12,7 +12,7 @@ LoadingObject::LoadingObject(DBStateServer *stateserver, doid_t do_id,
                              doid_t parent_id, zone_t zone_id,
                              const std::unordered_set<uint32_t> &contexts) :
     m_dbss(stateserver), m_do_id(do_id), m_parent_id(parent_id), m_zone_id(zone_id),
-    m_context(stateserver->m_next_context++), m_dclass(NULL), m_valid_contexts(contexts),
+    m_context(stateserver->m_next_context++), m_dclass(nullptr), m_valid_contexts(contexts),
     m_is_loaded(false)
 {
     std::stringstream name;

--- a/src/tests/MDParticipantTest.cpp
+++ b/src/tests/MDParticipantTest.cpp
@@ -15,7 +15,7 @@ class MDParticipantTest : public MDParticipantInterface
         dg2.add_channel(200);
         dg2.add_string("test");
 
-        MessageDirector::singleton.handle_datagram(NULL, dg2);
+        MessageDirector::singleton.handle_datagram(nullptr, dg2);
 
         unsubscribe_channel(100);
         unsubscribe_channel(200);

--- a/src/tests/MDPerformanceTest.cpp
+++ b/src/tests/MDPerformanceTest.cpp
@@ -10,7 +10,7 @@ LogCategory mdperf_log("PerfTestMD", "Performance Test - MessageDirector");
 #define MD_PERF_NUM_PARTICIPANTS 10
 #define MD_PERF_TIME 5.0
 #define MD_PERF_DATASIZE 70 //must be atleast 1+(MD_PERF_NUM_DEST_CHANNELS*sizeof(channel_t))
-uint8_t *data = NULL;
+uint8_t *data = nullptr;
 
 boost::random::mt19937_64 gen;
 


### PR DESCRIPTION
C++11 make the use of `NULL` ambiguous, letting the compiler chose whether to treat it as `nullptr` or `0` at compile time, making it also noteworthy that using `NULL` in templates deduces it to an integer.