### PR TITLE
Fix static-initialization ordering problems in config subsystem

### DIFF
--- a/src/clientagent/AstronClient.cpp
+++ b/src/clientagent/AstronClient.cpp
@@ -17,19 +17,20 @@ using boost::asio::ip::tcp;
 namespace ssl = boost::asio::ssl;
 
 
-static ConfigVariable<bool> relocate_owned("relocate", false, ca_client_config);
-static ConfigVariable<string> interest_permissions("add_interest", "visible", ca_client_config);
+static ConfigGroup astronclient_config("libastron", ca_client_config);
+static ConfigVariable<bool> relocate_owned("relocate", false, astronclient_config);
+static ConfigVariable<string> interest_permissions("add_interest", "visible", astronclient_config);
 static BooleanValueConstraint relocate_is_boolean(relocate_owned);
 
-static ConfigVariable<bool> send_hash_to_client("send_hash", true, ca_client_config);
-static ConfigVariable<bool> send_version_to_client("send_version", true, ca_client_config);
+static ConfigVariable<bool> send_hash_to_client("send_hash", true, astronclient_config);
+static ConfigVariable<bool> send_version_to_client("send_version", true, astronclient_config);
 
 static ConfigVariable<uint64_t> write_buffer_size("write_buffer_size", 256 * 1024,
-        ca_client_config);
-static ConfigVariable<unsigned int> write_timeout_ms("write_timeout_ms", 5000, ca_client_config);
+        astronclient_config);
+static ConfigVariable<unsigned int> write_timeout_ms("write_timeout_ms", 5000, astronclient_config);
 
 //by default, have heartbeat disabled.
-static ConfigVariable<long> heartbeat_timeout_config("heartbeat_timeout", 0, ca_client_config);
+static ConfigVariable<long> heartbeat_timeout_config("heartbeat_timeout", 0, astronclient_config);
 
 static bool is_permission_level(const string& str)
 {

--- a/src/clientagent/ClientAgent.cpp
+++ b/src/clientagent/ClientAgent.cpp
@@ -47,7 +47,7 @@ static InvalidChannelConstraint max_not_invalid(max_channel);
 static ReservedChannelConstraint min_not_reserved(min_channel);
 static ReservedChannelConstraint max_not_reserved(max_channel);
 
-ConfigGroup ca_client_config("client", clientagent_config);
+KeyedConfigGroup ca_client_config("client", "type", clientagent_config, "libastron");
 ConfigVariable<string> ca_client_type("type", "libastron", ca_client_config);
 bool have_client_type(const string& backend)
 {

--- a/src/clientagent/ClientAgent.h
+++ b/src/clientagent/ClientAgent.h
@@ -8,7 +8,7 @@
 #include <memory>
 
 extern RoleConfigGroup clientagent_config;
-extern ConfigGroup ca_client_config;
+extern KeyedConfigGroup ca_client_config;
 extern ConfigVariable<std::string> ca_client_type;
 
 // A ChannelTracker is used to keep track of available and allocated channels that

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -16,7 +16,7 @@ ConfigGroup& ConfigGroup::root()
 }
 
 // root constructor
-ConfigGroup::ConfigGroup() : m_name(""), m_path("")
+ConfigGroup::ConfigGroup() : m_name("")
 {
 }
 
@@ -24,7 +24,6 @@ ConfigGroup::ConfigGroup() : m_name(""), m_path("")
 ConfigGroup::ConfigGroup(const string& name, ConfigGroup& parent) : m_parent(&parent)
 {
     m_name = name;
-    m_path = parent.get_path() + name + "/";
     parent.m_children.insert(pair<string, ConfigGroup*>(name, this));
 }
 
@@ -49,7 +48,7 @@ bool ConfigGroup::validate(ConfigNode node)
     if(!node.IsMap()) {
         if(m_name.length() > 0) {
             // NOTE(Kevin): ConfigGroup is used for mappings, not sequences or scalars
-            config_log.error() << "Section '" << m_path
+            config_log.error() << "Section '" << get_path()
                                << "' has key/value config variables.\n";
         } else {
             // NOTE(Kevin): The root of the config file must be a mapping, not a sequence or scalar
@@ -69,7 +68,7 @@ bool ConfigGroup::validate(ConfigNode node)
         if(found_var != m_variables.end()) {
             rtest r = found_var->second;
             if(!r(node)) {
-                config_log.info() << "In Section '" << m_path << "', attribute '"
+                config_log.info() << "In Section '" << get_path() << "', attribute '"
                                   << key << "' did not match constraint (see error).\n";
                 ok = false;
             }
@@ -86,7 +85,7 @@ bool ConfigGroup::validate(ConfigNode node)
         }
 
         if(m_name.length() > 0) {
-            config_log.error() << "Section '" << m_path
+            config_log.error() << "Section '" << get_path()
                                << "' has no attribute named '" << key << "'.\n";
         } else {
             config_log.error() << "Section '" << key << "' is not a valid config category.\n";
@@ -112,7 +111,7 @@ bool KeyedConfigGroup::validate(ConfigNode node)
 {
     if(!node.IsMap()) {
         // NOTE(Kevin): KeyedConfigGroup is used for mappings, not sequences or scalars
-        config_log.error() << "Section '" << m_path
+        config_log.error() << "Section '" << get_path()
                            << "' expects a list of values.\n";
         return false;
     }
@@ -120,7 +119,7 @@ bool KeyedConfigGroup::validate(ConfigNode node)
     // NOTE(Kevin): A Keyed config group is validated based on the value of a known key;
     // typically the name of this key is "type"
     if(!node[m_key]) {
-        config_log.error() << "The section '" << m_path << "' did not specify the attribute '"
+        config_log.error() << "The section '" << get_path() << "' did not specify the attribute '"
                            << m_key << "'.\n";
         return false;
     }
@@ -131,7 +130,7 @@ bool KeyedConfigGroup::validate(ConfigNode node)
     if(found_grp == m_children.end()) {
         // A group doesn't exist whose name is the value of m_key
         config_log.error() << "The value '" << key << "' is not valid for attribute '"
-                           << m_key << "' of section '" << m_path << "'.\n";
+                           << m_key << "' of section '" << get_path() << "'.\n";
         print_keys();
         return false;
     }
@@ -165,7 +164,7 @@ bool ConfigList::validate(ConfigNode node)
 {
     if(!node.IsSequence()) {
         // NOTE(Kevin): ConfigList is used for sequences, not mappings or scalars
-        config_log.error() << "Section '" << m_path
+        config_log.error() << "Section '" << get_path()
                            << "' expects a list of values.\n";
         return false;
     }
@@ -195,7 +194,7 @@ bool KeyedConfigList::validate(ConfigNode node)
 {
     if(!node.IsSequence()) {
         // NOTE(Kevin): KeyedConfigList is used for sequences, not mappings or scalars
-        config_log.error() << "Section '" << m_path
+        config_log.error() << "Section '" << get_path()
                            << "' expects a list of values.\n";
         return false;
     }
@@ -207,7 +206,7 @@ bool KeyedConfigList::validate(ConfigNode node)
 
         // Items in a keyed config list must be a mapping include a key with the name from m_key
         if(!it->IsMap()) {
-            config_log.error() << "The " << n << "th item of section '" << m_path
+            config_log.error() << "The " << n << "th item of section '" << get_path()
                                << "' does not have key/value config variables.\n";
             ok = false;
             continue;
@@ -217,7 +216,7 @@ bool KeyedConfigList::validate(ConfigNode node)
         // in an items values; typically the name of this key "type"
         ConfigNode element = *it;
         if(!element[m_key]) {
-            config_log.error() << "The " << n << "th item of section '" << m_path
+            config_log.error() << "The " << n << "th item of section '" << get_path()
                                << "' did not specify the attribute '" << m_key << "'.\n";
             ok = false;
             continue;
@@ -227,7 +226,7 @@ bool KeyedConfigList::validate(ConfigNode node)
         auto found_grp = m_children.find(key);
         if(found_grp == m_children.end()) {
             config_log.error() << "The value '" << key << "' is not valid for attribute '"
-                               << m_key << "' of section '" << m_path << "'.\n";
+                               << m_key << "' of section '" << get_path() << "'.\n";
             print_keys();
             ok = false;
             continue;

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -15,6 +15,13 @@ ConfigGroup& ConfigGroup::root()
     return *root;
 }
 
+std::unordered_map<ConfigGroup*, std::unordered_map<std::string, ConfigGroup*>>&
+        ConfigGroup::config_tree()
+{
+    static std::unordered_map<ConfigGroup*, std::unordered_map<std::string, ConfigGroup*>> config_tree;
+    return config_tree;
+}
+
 // root constructor
 ConfigGroup::ConfigGroup() : m_name(""), m_parent(nullptr)
 {
@@ -23,7 +30,9 @@ ConfigGroup::ConfigGroup() : m_name(""), m_parent(nullptr)
 // constructor
 ConfigGroup::ConfigGroup(const string& name, ConfigGroup& parent) : m_name(name), m_parent(&parent)
 {
-    parent.get_children().insert(pair<string, ConfigGroup*>(name, this));
+    // m_parent might not be initialized yet, so we use this config_tree()
+    // mechanism so it knows who its children are before it gets initialized.
+    config_tree()[m_parent].insert(pair<string, ConfigGroup*>(name, this));
 }
 
 // destructor

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -105,8 +105,8 @@ bool ConfigGroup::validate(ConfigNode node)
 
 // constructor
 KeyedConfigGroup::KeyedConfigGroup(const string& name, const string& group_key,
-                                   ConfigGroup& parent) :
-    ConfigGroup(name, parent), m_key(group_key)
+                                   ConfigGroup& parent, const string& default_key) :
+    ConfigGroup(name, parent), m_key(group_key), m_default_key(default_key)
 {
 }
 
@@ -126,14 +126,20 @@ bool KeyedConfigGroup::validate(ConfigNode node)
 
     // NOTE(Kevin): A Keyed config group is validated based on the value of a known key;
     // typically the name of this key is "type"
+    string key;
     if(!node[m_key]) {
-        config_log.error() << "The section '" << get_path() << "' did not specify the attribute '"
-                           << m_key << "'.\n";
-        return false;
+        if(m_default_key != "") {
+            key = m_default_key;
+        } else {
+            config_log.error() << "The section '" << get_path() << "' did not specify the attribute '"
+                               << m_key << "'.\n";
+            return false;
+        }
+    } else {
+        key = node[m_key].as<string>();
     }
 
     // Find the appropriate config group for the value of m_key
-    string key = node[m_key].as<std::string>();
     auto found_grp = get_children().find(key);
     if(found_grp == get_children().end()) {
         // A group doesn't exist whose name is the value of m_key

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -16,7 +16,7 @@ ConfigGroup& ConfigGroup::root()
 }
 
 // root constructor
-ConfigGroup::ConfigGroup() : m_name("")
+ConfigGroup::ConfigGroup() : m_name(""), m_parent(nullptr)
 {
 }
 

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -21,9 +21,8 @@ ConfigGroup::ConfigGroup() : m_name("")
 }
 
 // constructor
-ConfigGroup::ConfigGroup(const string& name, ConfigGroup& parent) : m_parent(&parent)
+ConfigGroup::ConfigGroup(const string& name, ConfigGroup& parent) : m_name(name), m_parent(&parent)
 {
-    m_name = name;
     parent.m_children.insert(pair<string, ConfigGroup*>(name, this));
 }
 

--- a/src/config/ConfigGroup.cpp
+++ b/src/config/ConfigGroup.cpp
@@ -23,7 +23,7 @@ ConfigGroup::ConfigGroup() : m_name(""), m_parent(nullptr)
 // constructor
 ConfigGroup::ConfigGroup(const string& name, ConfigGroup& parent) : m_name(name), m_parent(&parent)
 {
-    parent.m_children.insert(pair<string, ConfigGroup*>(name, this));
+    parent.get_children().insert(pair<string, ConfigGroup*>(name, this));
 }
 
 // destructor
@@ -75,8 +75,8 @@ bool ConfigGroup::validate(ConfigNode node)
         }
 
         // Check if the key is a subgroup, if so recursively validate it
-        auto found_grp = m_children.find(key);
-        if(found_grp != m_children.end()) {
+        auto found_grp = get_children().find(key);
+        if(found_grp != get_children().end()) {
             if(!found_grp->second->validate(node[key])) {
                 ok = false;
             }
@@ -125,8 +125,8 @@ bool KeyedConfigGroup::validate(ConfigNode node)
 
     // Find the appropriate config group for the value of m_key
     string key = node[m_key].as<std::string>();
-    auto found_grp = m_children.find(key);
-    if(found_grp == m_children.end()) {
+    auto found_grp = get_children().find(key);
+    if(found_grp == get_children().end()) {
         // A group doesn't exist whose name is the value of m_key
         config_log.error() << "The value '" << key << "' is not valid for attribute '"
                            << m_key << "' of section '" << get_path() << "'.\n";
@@ -144,7 +144,7 @@ void KeyedConfigGroup::print_keys()
     auto out = config_log.info();
     out << "Expected value in '" << m_name << "',\n"
         << "    Candidates for attribute '" << m_key << "' are:\n";
-    for(auto it = m_children.begin(); it != m_children.end(); ++it) {
+    for(auto it = get_children().begin(); it != get_children().end(); ++it) {
         out << "        " << it->second->get_name() << "\n";
     }
     out << "\n";
@@ -222,8 +222,8 @@ bool KeyedConfigList::validate(ConfigNode node)
         }
 
         string key = element[m_key].as<std::string>();
-        auto found_grp = m_children.find(key);
-        if(found_grp == m_children.end()) {
+        auto found_grp = get_children().find(key);
+        if(found_grp == get_children().end()) {
             config_log.error() << "The value '" << key << "' is not valid for attribute '"
                                << m_key << "' of section '" << get_path() << "'.\n";
             print_keys();

--- a/src/config/ConfigGroup.h
+++ b/src/config/ConfigGroup.h
@@ -48,7 +48,7 @@ class ConfigGroup
     //     to the root separated by slashes, with the oldest ancestor at the beginning.
     inline std::string get_path() const
     {
-        return m_path;
+        return (m_parent == nullptr) ? "" : (m_parent->get_path() + m_name + "/");
     }
 
     // get_child_node returns the sub node of a given ConfigNode that
@@ -66,7 +66,7 @@ class ConfigGroup
 
   protected:
     ConfigGroup* m_parent;
-    std::string m_name, m_path;
+    std::string m_name;
 
     std::unordered_map<std::string, rtest> m_variables;
     std::unordered_map<std::string, ConfigGroup*> m_children;

--- a/src/config/ConfigGroup.h
+++ b/src/config/ConfigGroup.h
@@ -71,13 +71,15 @@ class ConfigGroup
     std::unordered_map<std::string, rtest> m_variables;
     inline std::unordered_map<std::string, ConfigGroup*>& get_children()
     {
-        return m_children;
+        return config_tree()[this];
     }
-    std::unordered_map<std::string, ConfigGroup*> m_children;
 
   private:
     ConfigGroup(); // root constructor
     void add_variable(const std::string&, rtest);
+
+    static std::unordered_map<ConfigGroup*, std::unordered_map<std::string, ConfigGroup*>>&
+            config_tree();
 };
 
 

--- a/src/config/ConfigGroup.h
+++ b/src/config/ConfigGroup.h
@@ -65,8 +65,8 @@ class ConfigGroup
     virtual bool validate(ConfigNode node);
 
   protected:
-    ConfigGroup* m_parent;
     std::string m_name;
+    ConfigGroup* m_parent;
 
     std::unordered_map<std::string, rtest> m_variables;
     std::unordered_map<std::string, ConfigGroup*> m_children;

--- a/src/config/ConfigGroup.h
+++ b/src/config/ConfigGroup.h
@@ -69,6 +69,10 @@ class ConfigGroup
     ConfigGroup* m_parent;
 
     std::unordered_map<std::string, rtest> m_variables;
+    inline std::unordered_map<std::string, ConfigGroup*>& get_children()
+    {
+        return m_children;
+    }
     std::unordered_map<std::string, ConfigGroup*> m_children;
 
   private:

--- a/src/config/ConfigGroup.h
+++ b/src/config/ConfigGroup.h
@@ -104,13 +104,14 @@ class KeyedConfigGroup : public ConfigGroup
 {
   public:
     KeyedConfigGroup(const std::string& name, const std::string& group_key,
-                     ConfigGroup& parent = ConfigGroup::root());
+                     ConfigGroup& parent = ConfigGroup::root(), const std::string& default_key = "");
     virtual ~KeyedConfigGroup();
 
     bool validate(ConfigNode node) override;
 
   protected:
     std::string m_key;
+    std::string m_default_key;
 
     // print_keys outputs all valid keys for the list into
     //     the Config log with Info severity.


### PR DESCRIPTION
**NOTE**: This DOES change client configuration to a KeyedConfigGroup. If you have a fork with a custom client type, please update your configuration appropriately.

This PR mainly changes `ConfigGroup` not to rely on its parent group in the constructor, because thanks to undefined static-initialization ordering, it might not be ready yet.