### PR TITLE
Add DB tests for various datatypes

### DIFF
--- a/test/common/astron.py
+++ b/test/common/astron.py
@@ -480,6 +480,11 @@ class DatagramIterator(object):
 
         return struct.unpack("<%ds" % length, self._data[self._offset-length:self._offset])[0]
 
+    def read_remainder(self):
+        remainder = self._data[self._offset:]
+        self._offset = len(self._data)
+        return remainder
+
     def seek(self, offset):
         self._offset = offset
 

--- a/test/common/astron.py
+++ b/test/common/astron.py
@@ -52,6 +52,8 @@ DATATYPES = {
     'uint32': '<I',
     'int64': '<q',
     'uint64': '<Q',
+    'char': '<s',
+    'float64': '<d',
 }
 
 CONSTANTS = {

--- a/test/common/dbserver.py
+++ b/test/common/dbserver.py
@@ -1260,10 +1260,10 @@ class DBServerTestsuite(object):
             ('int32', [88, 0, (1<<31)-1, -1<<31]),
             ('uint64', [88, 0, (1<<64)-1]),
             ('int64', [88, 0, (1<<63)-1, -1<<63]),
-            ('char',  ['H', 'i', '\x00', '\xff']),
+            ('char',  ['H', 'i', '\x00', '\x7f']),
             ('float64', [2.0, 8.7, -32.114]),
-            ('string', ['Hey', 'there', 'Astron', 'world']),
-            ('blob', ['\x00', '\xffabcdefgh', '\x00\x00\x00\x00\x01\x00\x00\x02']),
+            ('string', ['Hey', 'there', '', 'Astron', 'world']),
+            ('blob', ['\x00', '\xffabcdefgh', '', '\x00\x00\x00\x00\x01\x00\x00\x02']),
             ('fixstr', ['a'*32, 'b'*32, 'c'*32]),
             ('fixblob', ['d'*16, 'e'*16, 'f'*16])]:
             field_id = FIELDS.index('db_' + dbtype)

--- a/test/common/dbserver.py
+++ b/test/common/dbserver.py
@@ -1228,3 +1228,107 @@ class DBServerTestsuite(object):
         # Cleanup
         self.deleteObject(100, doid)
         self.conn.send(Datagram.create_remove_channel(100))
+
+    def test_datatypes(self):
+        # This uses a DistributedDBTypeTestObject and sets all of the various
+        # fields.
+        self.conn.flush()
+        self.conn.send(Datagram.create_add_channel(110))
+
+        # Create a (valid) object.
+        dg = Datagram.create([75757], 110, DBSERVER_CREATE_OBJECT)
+        dg.add_uint32(1) # Context
+        dg.add_uint16(DistributedDBTypeTestObject)
+        dg.add_uint16(0) # Field count
+        self.conn.send(dg)
+
+        dg = self.conn.recv_maybe()
+        self.assertTrue(dg is not None, "Did not receive CreateObjectResp.")
+        dgi = DatagramIterator(dg)
+        dgi.seek(CREATE_DOID_OFFSET)
+        doid = dgi.read_doid()
+
+        ctx = 0
+
+        # For each type, test several values:
+        for dbtype,dbvalues in [
+            ('uint8', [88, 0, (1<<8)-1]),
+            ('int8', [88, 0, (1<<7)-1, -1<<7]),
+            ('uint16', [88, 0, (1<<16)-1]),
+            ('int16', [88, 0, (1<<15)-1, -1<<15]),
+            ('uint32', [88, 0, (1<<32)-1]),
+            ('int32', [88, 0, (1<<31)-1, -1<<31]),
+            ('uint64', [88, 0, (1<<64)-1]),
+            ('int64', [88, 0, (1<<63)-1, -1<<63]),
+            ('char',  ['H', 'i', '\x00', '\xff']),
+            ('float64', [2.0, 8.7, -32.114]),
+            ('string', ['Hey', 'there', 'Astron', 'world']),
+            ('blob', ['\x00', '\xffabcdefgh', '\x00\x00\x00\x00\x01\x00\x00\x02']),
+            ('fixstr', ['a'*32, 'b'*32, 'c'*32]),
+            ('fixblob', ['d'*16, 'e'*16, 'f'*16])]:
+            field_id = FIELDS.index('db_' + dbtype)
+            if dbtype.startswith('fix'):
+                adder_func = 'add_raw'
+            else:
+                adder_func = 'add_' + dbtype
+
+            for dbvalue in dbvalues:
+                # Set the value...
+                dg = Datagram.create([75757], 110, DBSERVER_OBJECT_SET_FIELD)
+                dg.add_doid(doid)
+                dg.add_uint16(field_id)
+                getattr(dg, adder_func)(dbvalue)
+                self.conn.send(dg)
+
+                # Retrieve it back...
+                ctx += 1
+                dg = Datagram.create([75757], 110, DBSERVER_OBJECT_GET_FIELD)
+                dg.add_uint32(ctx) # Context
+                dg.add_doid(doid)
+                dg.add_uint16(field_id)
+                self.conn.send(dg)
+
+                # Get value in reply
+                dg = Datagram.create([110], 75757, DBSERVER_OBJECT_GET_FIELD_RESP)
+                dg.add_uint32(ctx) # Context
+                dg.add_uint8(SUCCESS)
+                dg.add_uint16(field_id)
+                getattr(dg, adder_func)(dbvalue)
+                self.expect(self.conn, dg)
+
+        # Finally we test the complex field, which contains a variable array, a
+        # fixed array, and structs.
+        def add_fields_to_complex(dg):
+            array_length = 5
+            dg.add_size(array_length * 3 * 4) # Byte size of named array
+            for i in xrange(array_length + 3): # Variable length array followed by fixed
+                # Each of these is a "Block" struct, which consists of 3 uint32s:
+                dg.add_uint32((i<<17) + ord('x'))
+                dg.add_uint32((i<<17) + ord('y'))
+                dg.add_uint32((i<<17) + ord('z'))
+
+        # Set:
+        dg = Datagram.create([75757], 110, DBSERVER_OBJECT_SET_FIELD)
+        dg.add_doid(doid)
+        dg.add_uint16(db_complex)
+        add_fields_to_complex(dg)
+        self.conn.send(dg)
+
+        # Retrieve it back...
+        ctx += 1
+        dg = Datagram.create([75757], 110, DBSERVER_OBJECT_GET_FIELD)
+        dg.add_uint32(ctx) # Context
+        dg.add_doid(doid)
+        dg.add_uint16(db_complex)
+        self.conn.send(dg)
+
+        # Get value in reply
+        dg = Datagram.create([110], 75757, DBSERVER_OBJECT_GET_FIELD_RESP)
+        dg.add_uint32(ctx) # Context
+        dg.add_uint8(SUCCESS)
+        dg.add_uint16(db_complex)
+        add_fields_to_complex(dg)
+        self.expect(self.conn, dg)
+
+        self.deleteObject(110, doid)
+        self.conn.send(Datagram.create_remove_channel(110))

--- a/test/common/dcfile.py
+++ b/test/common/dcfile.py
@@ -17,6 +17,7 @@ CLASSES = [
     'DistributedClientTestObject',
     'Block',
     'DistributedChunk',
+    'DistributedDBTypeTestObject',
 ]
 for i,n in enumerate(CLASSES):
     locals()[n] = i
@@ -76,7 +77,24 @@ FIELDS = [
     ### Fields for DistributedChunk ###
     'blockList',
     'lastBlock',
-    'newBlock'
+    'newBlock',
+
+    ### Fields for DistributedDBTypeTestObject ###
+    'db_uint8',
+    'db_uint16',
+    'db_uint32',
+    'db_uint64',
+    'db_int8',
+    'db_int16',
+    'db_int32',
+    'db_int64',
+    'db_char',
+    'db_float64',
+    'db_string',
+    'db_fixstr',
+    'db_blob',
+    'db_fixblob',
+    'db_complex',
 ]
 for i,n in enumerate(FIELDS):
     locals()[n] = i
@@ -87,4 +105,4 @@ setRDbD5DefaultValue = 20
 
 # If you edit test.dc *AT ALL*, you will have to recalculate this.
 # If you don't know how, ask CFS.
-DC_HASH = 0x7a9b0e3
+DC_HASH = 0x9a71149

--- a/test/files/test.dc
+++ b/test/files/test.dc
@@ -34,8 +34,8 @@ dclass DistributedTestObject4 {
 };
 
 dclass DistributedTestObject5 : DistributedTestObject3 {
-    setRDbD5(uint8 rdbd = 20) required db;
-    setFoo(uint16 foo) db;
+	setRDbD5(uint8 rdbd = 20) required db;
+	setFoo(uint16 foo) db;
 };
 
 dclass UberDog1 {
@@ -65,4 +65,22 @@ dclass DistributedChunk {
 	blockList(Block blocks[]) required clrecv;
 	lastBlock(Block block) ram clrecv airecv;
 	newBlock(Block block) broadcast;
+};
+
+dclass DistributedDBTypeTestObject {
+	uint8 db_uint8 db;
+	uint16 db_uint16 db;
+	uint32 db_uint32 db;
+	uint64 db_uint64 db;
+	int8 db_int8 db;
+	int16 db_int16 db;
+	int32 db_int32 db;
+	int64 db_int64 db;
+	char db_char db;
+	float64 db_float64 db;
+	string db_string db;
+	string(32) db_fixstr db;
+	blob db_blob db;
+	blob(16) db_fixblob db;
+	db_complex(Block named[], Block[3]) db;
 };


### PR DESCRIPTION
The various DB server(s) often convert Bamboo/Astron types to and from their backends' datatypes. As such, it's necessary to have tests to verify that this conversion works correctly.