### PR TITLE
Change how ownerviews behave to resemble OTP

### DIFF
--- a/src/clientagent/Client.h
+++ b/src/clientagent/Client.h
@@ -29,6 +29,13 @@ struct DeclaredObject {
     const dclass::Class *dcc;
 };
 
+// An OwnedObject is used to cache metadata associated with
+// a particular object when it becomes owned by a Client.
+struct OwnedObject : DeclaredObject {
+    doid_t parent;
+    zone_t zone;
+};
+
 // A VisibleObject is used to cache metadata associated with
 // a particular object when it becomes visible to a Client.
 struct VisibleObject : DeclaredObject {
@@ -102,8 +109,6 @@ class Client : public MDParticipantInterface
     channel_t m_allocated_channel = 0;      // Channel assigned to client at creation time
     uint32_t m_next_context = 1;
 
-    // m_owned_objects is a list of all objects visible through ownership
-    std::unordered_set<doid_t> m_owned_objects;
     // m_seen_objects is a list of all objects visible through interests
     std::unordered_set<doid_t> m_seen_objects;
     // m_session_objects is a list of objects that are automatically cleaned up when the
@@ -117,6 +122,8 @@ class Client : public MDParticipantInterface
     std::unordered_map<doid_t, VisibleObject> m_visible_objects;
     // m_declared_objects is a map of declared objects to their metadata.
     std::unordered_map<doid_t, DeclaredObject> m_declared_objects;
+    // m_owned_objects is a map of all owned objects to their metadata
+    std::unordered_map<doid_t, OwnedObject> m_owned_objects;
     // m_pending_objects is a map of doids for objects that we need to buffer dg's for
     std::unordered_map<doid_t, uint32_t> m_pending_objects;
 


### PR DESCRIPTION
In a nutshell, a client can have two views of an object: a DistributedObject instance and a DistributedObjectOV

The owner view instance (DistObjectOV) is created when the client receives _CLIENT\_ENTER\_OBJECT\_REQUIRED[\_OTHER]\_OWNER_ (i.e. as soon as _STATESERVER\_OBJECT\_SET\_OWNER_ is dispatched).

The "regular" view, on the other hand, only exists while the client has interest in the object's location.

For example, a game may give to the client the ownership of a DistributedShip object upon the avatar's login. That causes DistributedShipOV to generate. With that view, the client can hear some important updates: setMasts, setArmor and even send ownsend updates.

When the ship is deployed, the server moves it to a certain location so that the client may find it with an interest and generate a DistributedShip instance which loads the actual model with controls.

Toontown implements none of this and this commit shouldn't affect it. Pirates Online, on the other hand, relies a lot on this.

To support my claim, I'd like to point out that:

1 - Panda3D implements `self.doId2ownerView` and `self.doId2do` as two distinct maps.

2 - cConnectionRepository.cxx, in `handle_update_field_owner`, attempts to update both views. This goes to show that both instances do coexist.

Furthermore, many more evidences are present in Pirates Online / TLOPO code. Please contact me if
you'd like to see them.