### PR TITLE
Client: Use read_datagram instead of read_string

### DIFF
--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -371,7 +371,7 @@ void Client::handle_datagram(DatagramHandle in_dg, DatagramIterator &dgi)
     break;
     case CLIENTAGENT_SEND_DATAGRAM: {
         DatagramPtr forward = Datagram::create();
-        forward->add_data(dgi.read_string());
+        forward->add_data(dgi.read_datagram());
         forward_datagram(forward);
     }
     break;


### PR DESCRIPTION
Even though this works, it isn't a good idea to assume that Datagrams and strings will always have the same tag size. This was causing issues on a private fork where Datagram tags are 32-bit but strings are 16-bit.