### PR TITLE
Make dgsize_t and sizetag_t independent from each other

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,13 @@ find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 set(USE_32BIT_DATAGRAMS OFF CACHE BOOL
-	"If on, datagrams and dclass fields will use 32-bit length tags instead of 16-bit.")
+	"If on, datagrams will use 32-bit length tags instead of 16-bit.")
 if(USE_32BIT_DATAGRAMS)
 	add_definitions(-DASTRON_32BIT_DATAGRAMS)
+endif()
+set(USE_32BIT_SIZETAGS OFF CACHE BOOL
+	"If on, dclass fields will use 32-bit length tags instead of 16-bit.")
+if(USE_32BIT_SIZETAGS)
 	add_definitions(-DDCLASS_32BIT_SIZETAG)
 endif()
 set(USE_128BIT_CHANNELS OFF CACHE BOOL

--- a/src/database/MongoDatabase.cpp
+++ b/src/database/MongoDatabase.cpp
@@ -175,8 +175,8 @@ static void bamboo2bson(single_context builder,
     case dclass::Type::T_VARARRAY: {
         const dclass::ArrayType *array = type->as_array();
 
-        dgsize_t array_length = dgi.read_size();
-        dgsize_t starting_size = dgi.tell();
+        sizetag_t array_length = dgi.read_size();
+        sizetag_t starting_size = dgi.tell();
 
         auto sub_builder = builder << open_array;
 

--- a/src/messagedirector/MessageDirector.cpp
+++ b/src/messagedirector/MessageDirector.cpp
@@ -313,7 +313,7 @@ void MessageDirector::preroute_post_remove(channel_t sender, DatagramHandle post
     if(m_upstream != nullptr) {
         DatagramPtr dg = Datagram::create(CONTROL_ADD_POST_REMOVE);
         dg->add_channel(sender);
-        dg->add_blob(post_remove);
+        dg->add_datagram(post_remove);
         m_upstream->handle_datagram(dg);
     }
 }

--- a/test/test_clientagent.py
+++ b/test/test_clientagent.py
@@ -985,7 +985,7 @@ class TestClientAgent(ProtocolTest):
         dg.add_channel(id) # old parent
         self.server.send(dg)
         self.assertDisconnect(client, CLIENT_DISCONNECT_SESSION_OBJECT_DELETED)
-        
+
 
     def test_postremove(self):
         self.server.flush()
@@ -998,7 +998,7 @@ class TestClientAgent(ProtocolTest):
 
         # Add a post-remove...
         dg = Datagram.create([id], 1, CLIENTAGENT_ADD_POST_REMOVE)
-        dg.add_string(pr1.get_data())
+        dg.add_datagram(pr1)
         self.server.send(dg)
 
         # Clear the post-removes...
@@ -1007,11 +1007,11 @@ class TestClientAgent(ProtocolTest):
 
         # Add two different ones...
         dg = Datagram.create([id], 1, CLIENTAGENT_ADD_POST_REMOVE)
-        dg.add_string(pr2.get_data())
+        dg.add_datagram(pr2)
         self.server.send(dg)
 
         dg = Datagram.create([id], 1, CLIENTAGENT_ADD_POST_REMOVE)
-        dg.add_string(pr3.get_data())
+        dg.add_datagram(pr3)
         self.server.send(dg)
 
         #Wait
@@ -1034,7 +1034,7 @@ class TestClientAgent(ProtocolTest):
         raw_dg.add_channel(152379565)
 
         dg = Datagram.create([id], 1, CLIENTAGENT_SEND_DATAGRAM)
-        dg.add_string(raw_dg.get_data())
+        dg.add_datagram(raw_dg)
         self.server.send(dg)
 
         self.expect(client, raw_dg, isClient = True)
@@ -3459,7 +3459,7 @@ class TestClientAgent(ProtocolTest):
         #active socket.
         raw_dg = Datagram("Hello World")
         dg = Datagram.create([id], 1, CLIENTAGENT_SEND_DATAGRAM)
-        dg.add_string(raw_dg.get_data())
+        dg.add_datagram(raw_dg)
 
         #inital connection test
         self.server.send(dg)


### PR DESCRIPTION
There's no reason to force both to have the same size. Panda3D, for instance, supports 32-bit datagram tags (via `tcp-header-size` config) but requires 16-bit size tags for DC fields (e.g. strings and arrays).

This also implements`add_datagram` in Datagram, since they shouldn't be treated as blobs.
