### PR TITLE
Ignore channel 0 in notify_interest_done

### DIFF
--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -801,7 +801,7 @@ void Client::notify_interest_done(uint16_t interest_id, channel_t caller)
 // interest operation's caller, if one has been set.
 void Client::notify_interest_done(const InterestOperation* iop)
 {
-    if(iop->m_callers.size() == 0) {
+    if(iop->m_callers.size() == 0 || iop->m_channel==0) {
         return;
     }
 


### PR DESCRIPTION
Modify notify_interest_done overload to ignore requests from channel 0, part of issue #297