### PR TITLE
Disable CLIENTAGENT_DONE_INTEREST_RESP for channel 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the workload of managing a multi-sharded game/application environment with many 
 
 [![Build Status](https://travis-ci.org/Astron/Astron.svg?branch=master)](https://travis-ci.org/Astron/Astron)
 
-## Overview ## 
+## Overview ##
 
 ### Objects ###
 The core concept in an Astron environment is a DistributedObject. These represent individual game

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the workload of managing a multi-sharded game/application environment with many 
 
 [![Build Status](https://travis-ci.org/Astron/Astron.svg?branch=master)](https://travis-ci.org/Astron/Astron)
 
-## Overview ##
+## Overview ## 
 
 ### Objects ###
 The core concept in an Astron environment is a DistributedObject. These represent individual game

--- a/src/clientagent/Client.cpp
+++ b/src/clientagent/Client.cpp
@@ -845,11 +845,15 @@ void Client::notify_interest_done(const InterestOperation* iop)
     if(iop->m_callers.size() == 0) {
         return;
     }
-
-    DatagramPtr resp = Datagram::create(iop->m_callers, m_channel, CLIENTAGENT_DONE_INTEREST_RESP);
-    resp->add_channel(m_channel);
-    resp->add_uint16(iop->m_interest_id);
-    route_datagram(resp);
+	std::unordered_set<channel_t> m_callers;
+	for (channel_t c : iop->m_callers) {
+		if (c != 0)
+			m_callers.insert(m_callers.end(), c);
+	}
+		DatagramPtr resp = Datagram::create(m_callers, m_channel, CLIENTAGENT_DONE_INTEREST_RESP);
+		resp->add_channel(m_channel);
+		resp->add_uint16(iop->m_interest_id);
+		route_datagram(resp);
 }
 
 /* ========================== *


### PR DESCRIPTION
A solution to #297 that doesn't ignore any other channels besides 0 for possible future usage.