### PR TITLE
readme: Include libuv dependency; remove broken libyaml link

### DIFF
--- a/docs/building/build-readme.md
+++ b/docs/building/build-readme.md
@@ -21,10 +21,10 @@ On your machine clone with:
  * boost 1.55+
  * openssl 1.0.1+
 
-Get the boost library from http://www.boost.org/users/download/, or install from a package on linux.  Very old versions of the boost library may not work as there are dependencies on some features of boost::asio and boost::icl.
+Get the boost library from http://www.boost.org/users/download/, or install from a package on linux.  Very old versions of the boost library may not work as there are dependencies on some features of boost::icl.
 In some environments, you may have to set the BOOST_ROOT or BOOSTROOT environment variable to the root of your compiled boost libraries.
 
-You can get libyaml-cpp https://github.com/jbeder/yaml-cpp/. This dependency should typically be compiled and placed directly underneath the Astron/dependencies folder. Alternatively, you can install it from a package.
+You can get libyaml-cpp from https://github.com/jbeder/yaml-cpp/. This dependency should typically be compiled and placed directly underneath the Astron/dependencies folder. Alternatively, you can install it from a package.
 
 Grab the libuv dependency from https://github.com/libuv/libuv or install from a package on linux.
 

--- a/docs/building/build-readme.md
+++ b/docs/building/build-readme.md
@@ -17,13 +17,16 @@ On your machine clone with:
 ### Dependencies ###
 
  * libyaml-cpp 0.5+
+ * libuv 1.23.0+
  * boost 1.55+
  * openssl 1.0.1+
 
 Get the boost library from http://www.boost.org/users/download/, or install from a package on linux.  Very old versions of the boost library may not work as there are dependencies on some features of boost::asio and boost::icl.
 In some environments, you may have to set the BOOST_ROOT or BOOSTROOT environment variable to the root of your compiled boost libraries.
 
-You can download the libyaml-cpp dependency directly from https://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz.  This dependency should typically be compiled and placed directly underneath the Astron/dependencies folder.
+You can get libyaml-cpp https://github.com/jbeder/yaml-cpp/. This dependency should typically be compiled and placed directly underneath the Astron/dependencies folder. Alternatively, you can install it from a package.
+
+Grab the libuv dependency from https://github.com/libuv/libuv or install from a package on linux.
 
 Now that you have the dependencies you can build!
 


### PR DESCRIPTION
- Include libuv dependency + source location
- Replace broken libyaml link with updated source location
- Remove reference to boost:asio in note about old boost versions, since it's been replaced in Astron with libuv