### PR TITLE
readme: libyaml-cpp 0.6.0+ doesn't require boost

### DIFF
--- a/docs/building/build-readme.md
+++ b/docs/building/build-readme.md
@@ -18,11 +18,13 @@ On your machine clone with:
 
  * libyaml-cpp 0.5+
  * libuv 1.23.0+
- * boost 1.55+
+ * boost 1.55+ (optional if libyaml-cpp 0.6+)
  * openssl 1.0.1+
 
 Get the boost library from http://www.boost.org/users/download/, or install from a package on linux.  Very old versions of the boost library may not work as there are dependencies on some features of boost::icl.
 In some environments, you may have to set the BOOST_ROOT or BOOSTROOT environment variable to the root of your compiled boost libraries.
+
+**Note:** libyaml-cpp version 0.6.0 and above *no longer* requires the boost dependency.
 
 You can get libyaml-cpp from https://github.com/jbeder/yaml-cpp/. This dependency should typically be compiled and placed directly underneath the Astron/dependencies folder. Alternatively, you can install it from a package.
 


### PR DESCRIPTION
Correct me if I'm wrong, just noticed this as I was reading the compile instructions for libyaml-cpp.