### PR TITLE
Bash script for building on Linux with Make

### DIFF
--- a/scripts/build-make-linux.sh
+++ b/scripts/build-make-linux.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# NOTE: Run from repository root directory!
+
+cat > ./.git/info/exclude << EOF
+## Compilation Artifacts ##
+astrond
+*.[oa]
+CMakeCache.txt
+CMakeFiles/
+CTestTestfile.cmake
+cmake_install.cmake
+Makefile
+EOF
+
+BUILD_TYPE=$1
+if [[ -z $BUILD_TYPE ]];
+then
+    echo "No parameter passed; Building Astron release."
+    cmake -DCMAKE_BUILD_TYPE=Release . && make
+else
+    if [ $BUILD_TYPE == "release" ]; then
+        cmake -DCMAKE_BUILD_TYPE=Release . && make
+	exit 0
+    fi
+    if [ $BUILD_TYPE == "debug" ]; then
+        cmake -DCMAKE_BUILD_TYPE=Release . && make
+	exit 0
+    fi
+    if [ $BUILD_TYPE == "dev" ]; then
+        cmake . && make
+    fi
+    echo "Invalid build type parameter passed. ('release', 'debug', 'dev')"
+fi


### PR DESCRIPTION
Wrote a bash script that automates all the steps given in the build instructions for Linux/Make.
This includes setting up the `.git/info/exclude` file to ignore artifacts for Linux builds.

The script accepts one parameter for the build type. Valid parameters are 'release', 'debug', and 'dev'.
Feel free to propose edits to this contribution :)