### PR TITLE
gitignore: Ignore GNU Make/Linux build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
-# Ignore Mac's directory info
+## GNU Make/Linux Build Artifacts ##
+astrond
+*.[oa]
+CMakeCache.txt
+CMakeFiles/
+CTestTestfile.cmake
+cmake_install.cmake
+Makefile
+## Ignore Mac's directory info ##
 .DS_Store
 build/
 !build/.keep

--- a/docs/building/linux-gnu-make.md
+++ b/docs/building/linux-gnu-make.md
@@ -21,23 +21,3 @@ After setting up your environment you can compile with any of the following:
 **For development (without Trace and Debug messages):**
 
 	cmake . && make
-
-
-### Handling Build Artifacts ###
-When contributing to the Astron repository or a branch you should not add build
-artifacts to your commit.  Because build artifacts vary wildly between all the
-operating systems and compilers that Astron will compile with, they are not
-included in the `.gitignore` file.
-
-Instead, edit the `.git/info/exclude` file for your local clone.
-
-The following should be added for GNU Make on Linux:  
-```
-## Compilation Artifacts ##
-astrond
-*.[oa]
-CMakeCache.txt
-CMakeFiles/
-cmake_install.cmake
-Makefile
-```


### PR DESCRIPTION
Not sure why the build instructions for GNU Make/Linux say to specifically exclude these build artifacts from git via manually writing to the `.git/info/exclude` file instead of having these artifacts listed in the project gitignore instead.
The removed portion of the build instructions said this:
```
Because build artifacts vary wildly between all the operating systems
and compilers that Astron will compile with, they are not included in the .gitignore file.
```
We can include any artifacts (from any operating system Astron may be compiled in) in this file. 