### PR TITLE
core: Exit after astron_shutdown() is called without an exception

### DIFF
--- a/src/core/shutdown.cpp
+++ b/src/core/shutdown.cpp
@@ -58,7 +58,7 @@ static void handle_interrupt(int)
     }
 
     /*log->info()*/
-    cerr << "Received interrupt (Ctrl + C)\n";
+    cerr << "\nReceived interrupt (Ctrl + C)\n";
     astron_shutdown(0, false);
 }
 void astron_handle_signals()
@@ -83,6 +83,7 @@ void astron_shutdown(int code, bool throw_exception)
     if(throw_exception) {
         throw ShutdownException(code);
     }
+    exit(0); // no exception, exit with code 0
 }
 
 // astron_exit_code returns the exit code astron should exit with


### PR DESCRIPTION
If you interrupt the program (Ctrl + C), it will say "Exiting ..." and keep running with the exit mutex locked but no exit call.
This adds that missing exit call for manual interrupts that don't have an exception to throw when shutdown is called.